### PR TITLE
Fix: 커뮤니티 게시판의 카테고리 표시 유무 결정 및 CSS 수정&Feat: 홈 화면 및 검색 화면 개발

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "zustand": "^5.0.0-rc.2"
       },
       "devDependencies": {
+        "@tailwindcss/line-clamp": "^0.4.4",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -1033,6 +1034,15 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/line-clamp": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
+      "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
+      "dev": true,
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
     "node_modules/@tanstack/react-virtual": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "zustand": "^5.0.0-rc.2"
   },
   "devDependencies": {
+    "@tailwindcss/line-clamp": "^0.4.4",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/api/server/community.ts
+++ b/src/api/server/community.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { communityDetailSchema, communitySchema } from "@/schemas/communities";
+import { communityDetailSchema, communityResponseSchema, communitySchema } from "@/schemas/communities";
 import { CommunityProps } from "@/types/community";
 
 export const getCommunities = async (category: string = "none", page: string = "0") => {
@@ -11,15 +11,21 @@ export const getCommunities = async (category: string = "none", page: string = "
     if(!response.ok){
       throw new Error(`HTTP에러 상태 코드: ${response.status}`);
     }
-    const body = await response.json();
 
-    const validateData = communitySchema.array().parse(body.data);
-    console.log(validateData);
-    return validateData;
+    const body = await response.json();
+    console.log("::::::::::Fetched Data:", body);
+
+    const validateData = communityResponseSchema.parse(body);
+    console.log("::::::::::zod후 Data:", JSON.stringify(validateData, null, 2));
+    // const validateData = communitySchema.array().parse(body.data);
+    
+    console.log("::::::::::validateData.data는?:", validateData.data);
+    return validateData.data;
 
   } catch (error) {
     console.error(error);
-    return [];
+    // return [];
+    return { posts: [], totalPosts: 0, hasMore: false }; //아 여기 반환값 달라서 에러났던 거였음? 하...참나
   }
 };
 
@@ -175,6 +181,8 @@ export const getComments = async(postId: string) => {
   try {
     const response = await fetch(`https://api.dive-in.co.kr/community/comments/${postId}`);
     const body = await response.json();
+
+    
     return body;
   } catch (error) {
     console.log(error);

--- a/src/app/_components/BottomNav.tsx
+++ b/src/app/_components/BottomNav.tsx
@@ -3,11 +3,14 @@ import ChatIcon from "@/components/icons/ChatIcon";
 import PersonIcon from "@/components/icons/PersonIcon";
 import PoolIcon from "@/components/icons/PoolIcon";
 import SwimHatIcon from "@/components/icons/SwimHatIcon";
+import { GoHome } from "react-icons/go";
+
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 const routes = {
-  home: "/lessons",
+  home: "/",
+  lessons: "/lessons",
   pools: "/pools",
   // community: "/community/posts/list",
   community: "/community/posts/list?category=none&page=0",
@@ -19,7 +22,8 @@ const BottomNav = () => {
   const pathname = usePathname();
   // const searchParams = useSearchParams();
 
-  const isLessons = pathname.startsWith(routes.home);
+  const isHome = pathname.startsWith(routes.home);
+  const isLessons = pathname.startsWith(routes.lessons);
   const isPools = pathname.startsWith(routes.pools);
   const isCommunity = pathname.startsWith(routes.community);
   // const isCommunity = pathname.startsWith(routes.community) && searchParams.get("category") === "none";
@@ -34,6 +38,15 @@ const BottomNav = () => {
     <nav className="flex-none h-14 flex items-center px-4 bg-gray-100 border-t border-slate-200">
       <Link
         href={routes.home}
+        className={`flex-1 h-full flex flex-col gap-0.5 items-center justify-center ${
+          isHome ? "text-gray-900" : "text-gray-500"
+        }`}
+      >
+        <GoHome className={`h-6 w-6`} />
+        <span className={`text-label_sb`}>홈</span>
+      </Link>
+      <Link
+        href={routes.lessons}
         className={`flex-1 h-full flex flex-col gap-0.5 items-center justify-center ${
           isLessons ? "text-gray-900" : "text-gray-500"
         }`}

--- a/src/app/community/_components/CategoryFilter.tsx
+++ b/src/app/community/_components/CategoryFilter.tsx
@@ -31,15 +31,26 @@ export default function CategoryFilter({community, selectedCategory}: {
         href={`/community/posts/${community.postId}`}
         className="flex flex-col gap-2"
       >
-        <div className="flex-1 flex flex-row items-start gap-1 bg-white-100 rounded-lg p-2">
+        <div className="flex-1 flex flex-row items-start gap-1 bg-white-100 rounded-lg px-2">
           {/* 왼쪽 */}
-          <div className="flex-1 flex flex-col items-start gap-2">
+          <div className="flex-1 flex flex-col items-start gap-1.5">
             {/* 여기가 태그/인기 */}
-            {(selectedCategory === "none" || selectedCategory === "popular") &&
-              <div className={`text-label_sb px-1.5 py-1 rounded bg-chip-1 text-chip-1-foreground inline-block w-fit`}>
-                <p>{community.categoryName || "\u00A0"}</p>
-              </div>
-            }
+                <div className={`text-label_sb px-1.5 py-1 mt-4 rounded bg-chip-1 text-chip-1-foreground inline-block w-fit`}>
+                  <p>{community.categoryName || "\u00A0"}</p>
+                </div>
+              
+            
+            {/* {selectedCategory === "none" || selectedCategory === "popular" ? 
+              (
+                <div className={`text-label_sb px-1.5 py-1 mt-3 rounded bg-chip-1 text-chip-1-foreground inline-block w-fit`}>
+                  <p>{community.categoryName || "\u00A0"}</p>
+                </div>
+              ) : (
+                <div className={`text-label_sb px-1.5 py-0.5 w-fit`}>
+                  <p>&nbsp;</p>
+                </div>
+              )
+            } */}
 
             <div className="flex flex-col gap-0.5">
               <h3 className="text-gray-900 text-body_bb">
@@ -81,14 +92,28 @@ export default function CategoryFilter({community, selectedCategory}: {
 
           {/* 오른쪽 */}
           <div className="flex flex-col items-center w-24">
-            <div className="mt-6 w-25 h-25 overflow-hidden rounded-lg">
-              <img
+            
+          {selectedCategory === "none" || selectedCategory === "popular" ? 
+              (
+                <div className="mt-6 w-24 h-24 overflow-hidden rounded-lg">
+                  <img
                 src={community.image?.imageUrl || "/empty/community_thumbnail.png"}
                 alt="썸네일"
                 className="w-full h-full object-cover"
               />
-            </div>
-            <span className="mt-4 text-b text-gray-500 ml-auto">
+                </div>
+              ) : (
+                <div className="mt-5 w-24 h-24 overflow-hidden rounded-lg">
+                  <img
+                src={community.image?.imageUrl || "/empty/community_thumbnail.png"}
+                alt="썸네일"
+                className="w-full h-full object-cover"
+              />
+                </div>
+              )
+            }
+
+            <span className="mt-3 text-b text-gray-500 ml-auto">
               {/* {community.createdAt.split(" ")[0].slice(2)} */}
               {community.createdAt.slice(2,12)}
             </span>

--- a/src/app/community/_components/CategoryFilter.tsx
+++ b/src/app/community/_components/CategoryFilter.tsx
@@ -16,12 +16,16 @@ import { CATEGORIES } from "@/constants/categories";
 //   { name: "수영대회", key: "competition" },
 // ];
 
-export default function CategoryFilter({community, selectedCategory}: {
-  community: CommunitiesProps; 
+export default function CategoryFilter({
+  community,
+  selectedCategory,
+}: {
+  community: CommunitiesProps;
   selectedCategory: string;
 }) {
-  const categoryName = CATEGORIES.find((category) => 
-    category.key === selectedCategory)?.name || "알 수 없음";
+  const categoryName =
+    CATEGORIES.find((category) => category.key === selectedCategory)?.name ||
+    "알 수 없음";
 
   // console.warn(":::::::::::::::::::::::카테고리필터의 postID:", community.postId);
 
@@ -35,11 +39,12 @@ export default function CategoryFilter({community, selectedCategory}: {
           {/* 왼쪽 */}
           <div className="flex-1 flex flex-col items-start gap-1.5">
             {/* 여기가 태그/인기 */}
-                <div className={`text-label_sb px-1.5 py-1 mt-4 rounded bg-chip-1 text-chip-1-foreground inline-block w-fit`}>
-                  <p>{community.categoryName || "\u00A0"}</p>
-                </div>
-              
-            
+            <div
+              className={`text-label_sb px-1.5 py-1 mt-4 rounded bg-chip-1 text-chip-1-foreground inline-block w-fit`}
+            >
+              <p>{community.categoryName || "\u00A0"}</p>
+            </div>
+
             {/* {selectedCategory === "none" || selectedCategory === "popular" ? 
               (
                 <div className={`text-label_sb px-1.5 py-1 mt-3 rounded bg-chip-1 text-chip-1-foreground inline-block w-fit`}>
@@ -92,8 +97,17 @@ export default function CategoryFilter({community, selectedCategory}: {
 
           {/* 오른쪽 */}
           <div className="flex flex-col items-center w-24">
-            
-          {selectedCategory === "none" || selectedCategory === "popular" ? 
+            <div className="mt-6 w-24 h-24 overflow-hidden rounded-lg">
+              <img
+                src={
+                  community.image?.imageUrl || "/empty/community_thumbnail.png"
+                }
+                alt="썸네일"
+                className="w-full h-full object-cover"
+              />
+            </div>
+
+            {/* {selectedCategory === "none" || selectedCategory === "popular" ? 
               (
                 <div className="mt-6 w-24 h-24 overflow-hidden rounded-lg">
                   <img
@@ -111,11 +125,11 @@ export default function CategoryFilter({community, selectedCategory}: {
               />
                 </div>
               )
-            }
+            } */}
 
             <span className="mt-3 text-b text-gray-500 ml-auto">
               {/* {community.createdAt.split(" ")[0].slice(2)} */}
-              {community.createdAt.slice(2,12)}
+              {community.createdAt.slice(2, 12)}
             </span>
           </div>
         </div>

--- a/src/app/community/posts/[id]/clientPage.tsx
+++ b/src/app/community/posts/[id]/clientPage.tsx
@@ -124,12 +124,12 @@ export default function ClientCommunity({
     <div className="flex flex-col pb-10 relative h-full">
       {/* 상단Nav */}
       <div className="flex items-center justify-between py-1 px-1">
-        <Link href="/community/posts/list/none/0" className="flex p-3">
+        <Link href="/community/posts/list?category=none&page=0" className="flex p-3">
           <ArrowLeftIcon className="w-6 h-6 text-gray-900" />
         </Link>
 
         <button type="button" className="flex p-3" onClick={handleMenuOpen}>
-          <VscKebabVertical className="w-6  h-6 text-gray-900" />
+          <VscKebabVertical className="mt-1 w-6 h-6 text-gray-900" />
         </button>
       </div>
 

--- a/src/app/community/posts/list/clientPage.tsx
+++ b/src/app/community/posts/list/clientPage.tsx
@@ -6,7 +6,7 @@ import FloatingButton from "../../_components/FloatingButton";
 import CategoryFilter from "@/app/community/_components/CategoryFilter";
 import { getCommunities } from "@/api/server/community";
 import { useRouter } from "next/navigation";
-import { CommunitiesProps } from "@/types/community";
+import { CommunitiesProps, communityResponseDetailProps, communityResponseProps } from "@/types/community";
 import { CATEGORIES } from "@/constants/categories";
 
 // export const CATEGORIES = [
@@ -19,20 +19,23 @@ import { CATEGORIES } from "@/constants/categories";
 // ];
 
 export default function CommunitiesClient({ communityList, category, page }:{
-    communityList: CommunitiesProps[];
-    category: string;
+  // communityList: CommunitiesProps[];
+    communityList: communityResponseDetailProps;
+    category: string; 
     page: string;
+    // hasMore: boolean;
+    // totalposts: number;
   }) {
   const [selectedCategory, setSelectedCategory] = useState<string>(category); //기본 카테고리
-  const [communities, setCommunities] = useState<CommunitiesProps[]>(communityList); //초기 데이터
+  const [communities, setCommunities] = useState<CommunitiesProps[]>(communityList.posts); //초기 데이터
   const router = useRouter();
 
   //카테고리 변경시 URL 업데이트
   useEffect(() => {
     //카테고리 변경시 데이터 가져옴
     const fetchData = async() => {
-      const data = await getCommunities(selectedCategory, page);
-      setCommunities(data);
+      const data: communityResponseDetailProps = await getCommunities(selectedCategory, page);
+      setCommunities(data.posts);
     };
 
     fetchData();
@@ -62,8 +65,8 @@ export default function CommunitiesClient({ communityList, category, page }:{
         {/* {loading? (
           <p>로딩 중...</p>
         ) : ( */}
-          <ul className="flex flex-col gap-6 px-4 pb-10">
-          {communities.length > 0 ? (
+          <ul className="flex flex-col gap-1 px-4 pb-10">
+          {communities && communities.length > 0 ? (
             communities.map((community) => (
               <CategoryFilter key={community.postId} community={community} selectedCategory={selectedCategory} />
             ))

--- a/src/app/community/posts/list/page.tsx
+++ b/src/app/community/posts/list/page.tsx
@@ -29,7 +29,7 @@ export default async function CommunityPage({searchParams}: {searchParams: {cate
       <section className="flex flex-col">
         <div className="flex items-center gap-2 pt-6 px-4 pb-5">
           <h2 className="text-heading_2">{selectedCategoryName}</h2>
-          <p className="text-body_lb text-gray-500">{communities.length}</p>
+          {/* <p className="text-body_lb text-gray-500">{communities.posts.length}</p> */}
         </div>
 
         <div>

--- a/src/app/lessons/page.tsx
+++ b/src/app/lessons/page.tsx
@@ -37,7 +37,7 @@ export default async function LessonsPage() {
       <section className="flex flex-col">
         <div className="flex items-center gap-2 pt-6 px-4 pb-5">
           <h2 className="text-heading_2">수영 클래스</h2>
-          <p className="text-body_lb text-gray-500">{lessons.length}</p>
+          {/* <p className="text-body_lb text-gray-500">{lessons.length}</p> */}
         </div>
 
         <ul className="flex flex-col gap-6 px-4 pb-10">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,24 +1,393 @@
 "use client";
 
 import Image from "next/image";
+import { CiSearch } from "react-icons/ci";
+import ArrowRightIcon from "@/components/icons/ArrowRightIcon";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
+import Link from "next/link";
+import InstructorProfile from "./_components/InstructorProfile";
+import LessonChip from "@/components/ui/Chip";
 
 export default function Home() {
-  const router = useRouter();
-  useEffect(() => {
-    router.replace("/lessons");
-  }, [router]);
+  // const router = useRouter();
+  // useEffect(() => {
+  //   router.replace("/lessons");
+  // }, [router]);
 
   return (
-    <div className="flex flex-col items-center justify-center h-screen bg-white">
-      <Image
-        alt="로고"
-        src="/image/logo_w.png"
-        width={200}
-        height={200}
-        priority
-      />
+    // <div className="flex flex-col items-center justify-center h-screen bg-white">
+    //   <Image
+    //     alt="로고"
+    //     src="/image/logo_w.png"
+    //     width={200}
+    //     height={200}
+    //     priority
+    //   />
+    // </div>
+
+    <div className="flex flex-col">
+      <header className="flex gap-2 pt-4 px-4">
+        <div className="flex items-center gap-2">
+          <Image
+            alt="로고"
+            src="/image/logo_o.png"
+            width={68}
+            height={16}
+            className="h-4 w-[68px] object-cover"
+          />
+        </div>
+      </header>
+
+      {/* 검색창 */}
+      <section className="flex flex-col">
+        <div className="flex items-center gap-2 pt-6 px-4 pb-5">
+          {/* <h2 className="text-heading_2 text-gray-900">수영장</h2> */}
+          {/* <p className="text-body_lb text-gray-500">{pools.length}</p> */}
+          <div className="relative w-full">
+            <CiSearch
+              className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-500"
+              size={20}
+            />
+            <input
+              type="text"
+              placeholder="클래스명, 수영장, 커뮤니티 글을 검색해보세요"
+              className="w-full pl-10 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none"
+            ></input>
+          </div>
+        </div>
+      </section>
+
+      <section className="flex flex-col w-full pb-8">
+        <div className="flex flex-row px-4 py-2 justify-between">
+          <h2 className="text-heading_2 text-gray-900">
+            🔥인기있는 수영 클래스
+          </h2>
+          <Link href="/lessons" className="flex">
+            <ArrowRightIcon className="w-6 h-6 text-gray-900" />
+          </Link>
+        </div>
+        {/* 카드리스트 */}
+        <div className="grid grid-cols-2 gap-6 px-8 py-1">
+          {popularLessons.map((lesson) => (
+            <div
+              key={lesson.id}
+              className="p-6 rounded-lg shadow-sm bg-gray-100 flex flex-col h-full"
+            >
+              {/* 카드 1*/}
+              <div className="flex gap-2 items-center pb-2">
+                {lesson.chips.map((chip, index) => (
+                  <LessonChip key={index} label={chip} />
+                ))}
+              </div>
+              <h4 className="pb-10 text-xl font-bold text-gray-900 mb-1">
+                {lesson.title}
+              </h4>
+              <div className="mt-auto">
+                <InstructorProfile
+                  avatar={lesson.avatar}
+                  name={lesson.instructor}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="flex flex-col w-full pb-8">
+        <div className="flex flex-row px-4 py-2 justify-between">
+          <h2 className="pl-2 text-heading_2 text-gray-900">New 수영 클래스</h2>
+          <Link href="/lessons" className="flex">
+            <ArrowRightIcon className="w-6 h-6 text-gray-900" />
+          </Link>
+        </div>
+        {/* 카드리스트 */}
+        <div className="grid grid-cols-2 gap-6 px-8 py-1">
+          {/* 카드 1*/}
+          <div className="p-6 rounded-lg shadow-sm bg-gray-100 flex flex-col h-full">
+            <div className="flex gap-2 items-center pb-2">
+              <LessonChip label="중급" />
+              <LessonChip label="접영" />
+            </div>
+            <h4 className="pb-10 text-xl font-bold text-gray-900 mb-1">
+              마스터즈 평일
+            </h4>
+            {/* <p className="text-md text-gray-700">수달상회</p> */}
+            <div className="mt-auto">
+              <InstructorProfile avatar="" name="물곰TV" />
+            </div>
+          </div>
+
+          {/* 카드 2*/}
+          <div className="p-6 rounded-lg shadow-sm bg-gray-100 flex flex-col h-full">
+            <div className="flex gap-2 items-center pb-2">
+              <LessonChip label="초급" />
+              <LessonChip label="접영" />
+              <LessonChip label="다이빙" />
+              {/* <span className="bg-pink-100 text-pink-500 text-xs font-bold px-2 py-1 rounded">접영</span> */}
+            </div>
+            <h3 className="pb-10 text-xl font-bold text-gray-900 mb-1">
+              청소년 선수반
+            </h3>
+            <div className="mt-auto">
+              <InstructorProfile avatar="" name="4레인" />
+            </div>
+            {/* <p className="text-md text-gray-700">수달상회</p> */}
+          </div>
+        </div>
+      </section>
+
+      <section className="flex flex-col w-full pb-8">
+        <div className="flex flex-row px-4 py-2 justify-between">
+          <h2 className="text-heading_2 text-gray-900">
+            🔥인기있는 커뮤니티 글
+          </h2>
+          <Link href="/lessons" className="flex">
+            <ArrowRightIcon className="w-6 h-6 text-gray-900" />
+          </Link>
+        </div>
+        {/* 카드리스트 */}
+        <div className="grid grid-rows-2 gap-6 px-8 py-1">
+          {/* 카드 1*/}
+          <div className="p-6 rounded-lg shadow-sm bg-gray-100 flex flex-col h-full">
+            <div className="flex gap-2 items-center pb-2">
+              <div
+                className={`text-label_sb px-1.5 py-1 mt-4 rounded bg-chip-1 text-chip-1-foreground inline-block w-fit`}
+              >
+                <p>커뮤니티</p>
+              </div>
+            </div>
+            <div className="pb-4 text-gray-900 mb-1">
+              <h4 className="text-xl font-bold">수영대회 찾는 중</h4>
+              <p className="text-md text-gray-500">안녕하세요</p>
+            </div>
+            <div className="mt-auto">
+              <InstructorProfile avatar="" name="수달상회" />
+            </div>
+          </div>
+
+          {/* 카드 2*/}
+          <div className="p-6 rounded-lg shadow-sm bg-gray-100 flex flex-col h-full">
+            <div className="flex gap-2 items-center pb-2">
+              <LessonChip label="초급" />
+              <LessonChip label="접영" />
+              <LessonChip label="다이빙" />
+              {/* <span className="bg-pink-100 text-pink-500 text-xs font-bold px-2 py-1 rounded">접영</span> */}
+            </div>
+            <h3 className="pb-10 text-xl font-bold text-gray-900 mb-1">
+              유소년 선수반
+            </h3>
+            <div className="mt-auto">
+              <InstructorProfile avatar="" name="이지스윔" />
+            </div>
+            {/* <p className="text-md text-gray-700">수달상회</p> */}
+          </div>
+        </div>
+      </section>
+
+      <section className="flex flex-col w-full pb-8">
+        <div className="flex flex-row px-4 py-2 justify-between">
+          <h2 className="pl-2 text-heading_2 text-gray-900">New 커뮤니티 글</h2>
+          <Link href="/lessons" className="flex">
+            <ArrowRightIcon className="w-6 h-6 text-gray-900" />
+          </Link>
+        </div>
+        {/* 카드리스트 */}
+        <div className="grid grid-cols-2 gap-6 px-8 py-1">
+          {/* 카드 1*/}
+          <div className="p-6 rounded-lg shadow-sm bg-gray-100 flex flex-col h-full">
+            <div className="flex gap-2 items-center pb-2">
+              <LessonChip label="고급" />
+              <LessonChip label="접영" />
+            </div>
+            <h4 className="pb-10 text-xl font-bold text-gray-900 mb-1">
+              마스터즈 평일 교정 훈련 클래스 가나다
+            </h4>
+            {/* <p className="text-md text-gray-700">수달상회</p> */}
+            <div className="mt-auto">
+              <InstructorProfile avatar="" name="수달상회" />
+            </div>
+          </div>
+
+          {/* 카드 2*/}
+          <div className="p-6 rounded-lg shadow-sm bg-gray-100 flex flex-col h-full">
+            <div className="flex gap-2 items-center pb-2">
+              <LessonChip label="초급" />
+              <LessonChip label="접영" />
+              <LessonChip label="다이빙" />
+              {/* <span className="bg-pink-100 text-pink-500 text-xs font-bold px-2 py-1 rounded">접영</span> */}
+            </div>
+            <h3 className="pb-10 text-xl font-bold text-gray-900 mb-1">
+              유소년 선수반
+            </h3>
+            <div className="mt-auto">
+              <InstructorProfile avatar="" name="이지스윔" />
+            </div>
+            {/* <p className="text-md text-gray-700">수달상회</p> */}
+          </div>
+        </div>
+      </section>
+
+      <section className="flex flex-col w-full pb-8">
+        <div className="flex flex-row px-4 py-2 justify-between">
+          <h2 className="pl-2 text-heading_2 text-gray-900">
+            모집중인 수영대회
+          </h2>
+          <Link href="/lessons" className="flex">
+            <ArrowRightIcon className="w-6 h-6 text-gray-900" />
+          </Link>
+        </div>
+        {/* 카드리스트 */}
+        <div className="grid grid-cols-2 gap-6 px-8 py-1">
+          {/* 카드 1*/}
+          <div className="p-6 rounded-lg shadow-sm bg-gray-100 flex flex-col h-full">
+            <div className="flex gap-2 items-center pb-2">
+              <LessonChip label="고급" />
+              <LessonChip label="접영" />
+            </div>
+            <h4 className="pb-10 text-xl font-bold text-gray-900 mb-1">
+              마스터즈 평일 교정 훈련 클래스 가나다
+            </h4>
+            {/* <p className="text-md text-gray-700">수달상회</p> */}
+            <div className="mt-auto">
+              <InstructorProfile avatar="" name="수달상회" />
+            </div>
+          </div>
+
+          {/* 카드 2*/}
+          <div className="p-6 rounded-lg shadow-sm bg-gray-100 flex flex-col h-full">
+            <div className="flex gap-2 items-center pb-2">
+              <LessonChip label="초급" />
+              <LessonChip label="접영" />
+              <LessonChip label="다이빙" />
+              {/* <span className="bg-pink-100 text-pink-500 text-xs font-bold px-2 py-1 rounded">접영</span> */}
+            </div>
+            <h3 className="pb-10 text-xl font-bold text-gray-900 mb-1">
+              유소년 선수반
+            </h3>
+            <div className="mt-auto">
+              <InstructorProfile avatar="" name="이지스윔" />
+            </div>
+            {/* <p className="text-md text-gray-700">수달상회</p> */}
+          </div>
+        </div>
+      </section>
+
+      {/* <ul className="grid grid-cols-2 gap-4 px-4 pb-10"></ul> */}
     </div>
   );
 }
+
+const popularLessons = [
+  {
+    id: 1,
+    chips: ["고급", "접영"],
+    title: "마스터즈 평일 교정 훈련 클래스 20글자",
+    avatar: "",
+    instructor: "수달상회",
+  },
+  {
+    id: 2,
+    chips: ["초급", "접영", "다이빙"],
+    title: "유소년 선수반",
+    avatar: "",
+    instructor: "이지스윔",
+  },
+];
+
+const NewLessons = [
+  {
+    id: 1,
+    chips: ["중급", "접영"],
+    title: "마스터즈 평일",
+    avatar: "",
+    instructor: "물곰TV",
+  },
+  {
+    id: 2,
+    chips: ["초급", "접영", "다이빙"],
+    title: "청소년 선수반",
+    avatar: "",
+    instructor: "4레인",
+  },
+];
+
+const popularCommunities = [
+  {
+    id: 1,
+    categoryName: "커뮤니티",
+    title: "수영대회 찾는 중",
+    content:
+      "안녕하세요, 수영대회에 관심있는 수영장 처돌이입니다. 수영대회 찾아요.",
+    images: {
+      repImage: true,
+      imageUrl:
+        "https://dive-in-bucket.kr.object.ncloudstorage.com/2ae3190a-97d6-4600-9e27-470920503c26.jpg",
+    },
+    likesCnt: 13,
+    cmmtCnt: 5,
+    viewCnt: 0,
+  },
+  {
+    id: 2,
+    categoryName: "수영물품",
+    title: "수영물품 구해요",
+    content: "수모수모수모",
+    images: null,
+    likesCnt: 13,
+    cmmtCnt: 5,
+    viewCnt: 0,
+  },
+];
+
+const NewCommunities = [
+  {
+    id: 1,
+    categoryName: "커뮤니티",
+    title: "수영대회 찾는 중",
+    content:
+      "안녕하세요, 수영대회에 관심있는 수영장 처돌이입니다. 수영대회 찾아요.",
+    images: {
+      repImage: true,
+      imageUrl:
+        "https://dive-in-bucket.kr.object.ncloudstorage.com/2ae3190a-97d6-4600-9e27-470920503c26.jpg",
+    },
+    likesCnt: 13,
+    cmmtCnt: 5,
+    viewCnt: 0,
+  },
+  {
+    id: 2,
+    categoryName: "커뮤니티",
+    title: "안녕하세요~~~~~~~~~",
+    content: "수모수모수모",
+    images: null,
+    likesCnt: 13,
+    cmmtCnt: 5,
+    viewCnt: 0,
+  },
+];
+
+const swimContests = [
+  {
+    id: 1,
+    categoryName: "수영대회",
+    title: "2024 MAC배 전국수영대회",
+    period: "2024.11.16 ~ 2024.11.20",
+    dDay: "D-7",
+  },
+  {
+    id: 2,
+    categoryName: "수영대회",
+    title: "2025년 수구 국가대표 및 국가대표 후보선수 선발대회",
+    period: "2024.11.16 ~ 2024.11.20",
+    dDay: "D-71",
+  },
+  {
+    id: 3,
+    categoryName: "수영대회",
+    title: "2026년 하계 올림픽 대표팀 최종 선발전",
+    period: "2026.06.01 ~ 2026.06.05",
+    dDay: "D-14",
+  },
+];

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,17 +4,38 @@ import Image from "next/image";
 import { CiSearch } from "react-icons/ci";
 import ArrowRightIcon from "@/components/icons/ArrowRightIcon";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import InstructorProfile from "./_components/InstructorProfile";
 import LessonChip from "@/components/ui/Chip";
+import { LuEye } from "react-icons/lu";
+import { FiMessageSquare } from "react-icons/fi";
+import { TiHeartOutline } from "react-icons/ti";
 
-export default function Home() {
+export default function Home({content}: {content: string}) {
   // const router = useRouter();
   // useEffect(() => {
   //   router.replace("/lessons");
   // }, [router]);
+    const [maxLength, setMaxLength] = useState(10);
 
+    useEffect(()=> {
+      const handleResize = () => {
+        if(window.innerWidth < 640) {
+          setMaxLength(15);
+        }else if(window.innerWidth < 1024) {
+          setMaxLength(20);
+        }else{
+          setMaxLength(25);
+        }
+      };
+
+      handleResize();
+      window.addEventListener("resize", handleResize);
+
+      return () => window.removeEventListener("resize", handleResize);
+    }, []);
+  
   return (
     // <div className="flex flex-col items-center justify-center h-screen bg-white">
     //   <Image
@@ -103,37 +124,28 @@ export default function Home() {
         </div>
         {/* 카드리스트 */}
         <div className="grid grid-cols-2 gap-6 px-8 py-1">
-          {/* 카드 1*/}
-          <div className="p-6 rounded-lg shadow-sm bg-gray-100 flex flex-col h-full">
-            <div className="flex gap-2 items-center pb-2">
-              <LessonChip label="중급" />
-              <LessonChip label="접영" />
+          {NewLessons.map((lesson) => (
+            <div
+              key={lesson.id}
+              className="p-6 rounded-lg shadow-sm bg-gray-100 flex flex-col h-full"
+            >
+              {/* 카드 1*/}
+              <div className="flex gap-2 items-center pb-2">
+                {lesson.chips.map((chip, index) => (
+                  <LessonChip key={index} label={chip} />
+                ))}
+              </div>
+              <h4 className="pb-10 text-xl font-bold text-gray-900 mb-1">
+                {lesson.title}
+              </h4>
+              <div className="mt-auto">
+                <InstructorProfile
+                  avatar={lesson.avatar}
+                  name={lesson.instructor}
+                />
+              </div>
             </div>
-            <h4 className="pb-10 text-xl font-bold text-gray-900 mb-1">
-              마스터즈 평일
-            </h4>
-            {/* <p className="text-md text-gray-700">수달상회</p> */}
-            <div className="mt-auto">
-              <InstructorProfile avatar="" name="물곰TV" />
-            </div>
-          </div>
-
-          {/* 카드 2*/}
-          <div className="p-6 rounded-lg shadow-sm bg-gray-100 flex flex-col h-full">
-            <div className="flex gap-2 items-center pb-2">
-              <LessonChip label="초급" />
-              <LessonChip label="접영" />
-              <LessonChip label="다이빙" />
-              {/* <span className="bg-pink-100 text-pink-500 text-xs font-bold px-2 py-1 rounded">접영</span> */}
-            </div>
-            <h3 className="pb-10 text-xl font-bold text-gray-900 mb-1">
-              청소년 선수반
-            </h3>
-            <div className="mt-auto">
-              <InstructorProfile avatar="" name="4레인" />
-            </div>
-            {/* <p className="text-md text-gray-700">수달상회</p> */}
-          </div>
+          ))}
         </div>
       </section>
 
@@ -147,41 +159,87 @@ export default function Home() {
           </Link>
         </div>
         {/* 카드리스트 */}
-        <div className="grid grid-rows-2 gap-6 px-8 py-1">
-          {/* 카드 1*/}
-          <div className="p-6 rounded-lg shadow-sm bg-gray-100 flex flex-col h-full">
-            <div className="flex gap-2 items-center pb-2">
-              <div
-                className={`text-label_sb px-1.5 py-1 mt-4 rounded bg-chip-1 text-chip-1-foreground inline-block w-fit`}
-              >
-                <p>커뮤니티</p>
+        <div className="flex flex-wrap gap-6 px-8 py-1">
+          {popularCommunities.map((community) => (
+            <div
+              key={community.id}
+              className="px-4 py-2 rounded-lg shadow-sm bg-gray-100 w-full"
+            >
+              {/* 카드 1*/}
+              <div className="items-center gap-2 pb-2">
+                <Link
+                  href={`/community/posts/${community.id}`}
+                  className=""
+                >
+                  
+                  {/* 박스 내용물 하나 */}
+                  <div className="flex flex-row justify-between items-start w-full rounded-lg px-2">
+                    
+                    {/* 왼쪽 */}
+                    <div className="flex-1 min-w-0 max-w-[80%] flex flex-col items-start gap-1.5 overflow-hidden">
+                      {/* 여기가 태그/인기 */}
+                      <div
+                        className={`text-label_sb px-1.5 py-1 mt-4 rounded bg-chip-1 text-chip-1-foreground inline-block w-fit`}
+                      >
+                        <p>{community.categoryName || "\u00A0"}</p>
+                      </div>
+                      <div className="flex flex-col gap-0.5">
+                        <h3 className="text-gray-900 text-body_bb">
+                          {/* {community.communityTitle} */}
+                          {community.title}
+                        </h3>
+                      </div>
+                        {/* <p className="text-body_b text-gray-600 block truncate xs:max-w-[100px] sm:max-w-[200px] md:max-w-[300px] lg:max-w-[400px] "> */}
+                      <div className="flex items-center gap-1 overflow-hidden min-w-0">
+                        <p className="text-body_b text-gray-600 block truncate w-full">
+                          {community.content.length > maxLength ? `${community.content.substring(0, maxLength)}...`
+                          : community.content}
+                        </p>
+                      </div>
+
+                      {/* <div className="flex items-center gap-1">
+              <WriterProfile
+                avatar={community.writerProfile}
+                name={community.writer}
+              />
+            </div> */}
+
+                      <div className="flex flex-row items-center gap-4">
+                        <div className="flex items-center gap-1">
+                          <LuEye className="w-5 h-5 text-gray-400" />
+                          <p className="text-gray-500"> {community.viewCnt}</p>
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <FiMessageSquare className="w-5 h-5 text-gray-400" />
+                          <p className="text-gray-500">{community.cmmtCnt}</p>
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <TiHeartOutline className="w-5 h-5 text-gray-400" />
+                          <p className="text-gray-500"> {community.likesCnt}</p>
+                        </div>
+                      </div>
+                    </div>
+
+
+                    {/* 오른쪽 */}
+                    {/* <div className="flex flex-col items-center w-24 flex-shrink-0"> */}
+                    <div className="mt-6 items-center w-24 flex-shrink-0">
+                      {/* <div className="mt-6 w-24 h-24 overflow-hidden rounded-lg"> */}
+                        <img
+                          src={
+                            community.images?.imageUrl ||
+                            "/empty/community_thumbnail.png"
+                          }
+                          alt="썸네일"
+                          className="w-24 h-24 object-cover rounded-lg"
+                        />
+                      {/* </div> */}
+                    </div>
+                  </div>
+                </Link>
               </div>
             </div>
-            <div className="pb-4 text-gray-900 mb-1">
-              <h4 className="text-xl font-bold">수영대회 찾는 중</h4>
-              <p className="text-md text-gray-500">안녕하세요</p>
-            </div>
-            <div className="mt-auto">
-              <InstructorProfile avatar="" name="수달상회" />
-            </div>
-          </div>
-
-          {/* 카드 2*/}
-          <div className="p-6 rounded-lg shadow-sm bg-gray-100 flex flex-col h-full">
-            <div className="flex gap-2 items-center pb-2">
-              <LessonChip label="초급" />
-              <LessonChip label="접영" />
-              <LessonChip label="다이빙" />
-              {/* <span className="bg-pink-100 text-pink-500 text-xs font-bold px-2 py-1 rounded">접영</span> */}
-            </div>
-            <h3 className="pb-10 text-xl font-bold text-gray-900 mb-1">
-              유소년 선수반
-            </h3>
-            <div className="mt-auto">
-              <InstructorProfile avatar="" name="이지스윔" />
-            </div>
-            {/* <p className="text-md text-gray-700">수달상회</p> */}
-          </div>
+          ))}
         </div>
       </section>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -65,17 +65,20 @@ export default function Home({content}: {content: string}) {
         <div className="flex items-center gap-2 pt-6 px-4 pb-5">
           {/* <h2 className="text-heading_2 text-gray-900">수영장</h2> */}
           {/* <p className="text-body_lb text-gray-500">{pools.length}</p> */}
+          <Link href="/search" className="relative w-full">
           <div className="relative w-full">
             <CiSearch
-              className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-500"
-              size={20}
-            />
+                className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-500"
+                size={20}
+              />
             <input
               type="text"
               placeholder="클래스명, 수영장, 커뮤니티 글을 검색해보세요"
               className="w-full pl-10 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none"
-            ></input>
+              ></input>
           </div>
+              </Link>
+
         </div>
       </section>
 
@@ -167,14 +170,12 @@ export default function Home({content}: {content: string}) {
             >
               {/* 카드 1*/}
               <div className="items-center gap-2 pb-2">
-                <Link
+                {/* <Link
                   href={`/community/posts/${community.id}`}
                   className=""
-                >
-                  
+                > */}
                   {/* 박스 내용물 하나 */}
                   <div className="flex flex-row justify-between items-start w-full rounded-lg px-2">
-                    
                     {/* 왼쪽 */}
                     <div className="flex-1 min-w-0 max-w-[80%] flex flex-col items-start gap-1.5 overflow-hidden">
                       {/* 여기가 태그/인기 */}
@@ -220,6 +221,96 @@ export default function Home({content}: {content: string}) {
                       </div>
                     </div>
 
+                    {/* 오른쪽 */}
+                    {/* <div className="flex flex-col items-center w-24 flex-shrink-0"> */}
+                    <div className="mt-6 items-center w-24 flex-shrink-0">
+                      {/* <div className="mt-6 w-24 h-24 overflow-hidden rounded-lg"> */}
+                        <img
+                          src={
+                            community.images?.imageUrl ||
+                            "/empty/community_thumbnail.png"
+                          }
+                          alt="썸네일"
+                          className="w-24 h-24 object-cover rounded-lg"
+                        />
+                      {/* </div> */}
+                    </div>
+                  </div>
+                {/* </Link> */}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="flex flex-col w-full pb-8">
+        <div className="flex flex-row px-4 py-2 justify-between">
+          <h2 className="pl-2 text-heading_2 text-gray-900">
+            New 커뮤니티 글
+          </h2>
+          <Link href="/lessons" className="flex">
+            <ArrowRightIcon className="w-6 h-6 text-gray-900" />
+          </Link>
+        </div>
+        {/* 카드리스트 */}
+        <div className="flex flex-wrap gap-6 px-8 py-1">
+          {NewCommunities.map((community) => (
+            <div
+              key={community.id}
+              className="px-4 py-2 rounded-lg shadow-sm bg-gray-100 w-full"
+            >
+              {/* 카드 1*/}
+              <div className="items-center gap-2 pb-2">
+                {/* <Link
+                  href={`/community/posts/${community.id}`}
+                  className=""
+                > */}
+                  {/* 박스 내용물 하나 */}
+                  <div className="flex flex-row justify-between items-start w-full rounded-lg px-2">
+                    {/* 왼쪽 */}
+                    <div className="flex-1 min-w-0 max-w-[80%] flex flex-col items-start gap-1.5 overflow-hidden">
+                      {/* 여기가 태그/인기 */}
+                      <div
+                        className={`text-label_sb px-1.5 py-1 mt-4 rounded bg-chip-1 text-chip-1-foreground inline-block w-fit`}
+                      >
+                        <p>{community.categoryName || "\u00A0"}</p>
+                      </div>
+                      <div className="flex flex-col gap-0.5">
+                        <h3 className="text-gray-900 text-body_bb">
+                          {/* {community.communityTitle} */}
+                          {community.title}
+                        </h3>
+                      </div>
+                        {/* <p className="text-body_b text-gray-600 block truncate xs:max-w-[100px] sm:max-w-[200px] md:max-w-[300px] lg:max-w-[400px] "> */}
+                      <div className="flex items-center gap-1 overflow-hidden min-w-0">
+                        <p className="text-body_b text-gray-600 block truncate w-full">
+                          {community.content.length > maxLength ? `${community.content.substring(0, maxLength)}...`
+                          : community.content}
+                        </p>
+                      </div>
+
+                      {/* <div className="flex items-center gap-1">
+              <WriterProfile
+                avatar={community.writerProfile}
+                name={community.writer}
+              />
+            </div> */}
+
+                      <div className="flex flex-row items-center gap-4">
+                        <div className="flex items-center gap-1">
+                          <LuEye className="w-5 h-5 text-gray-400" />
+                          <p className="text-gray-500"> {community.viewCnt}</p>
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <FiMessageSquare className="w-5 h-5 text-gray-400" />
+                          <p className="text-gray-500">{community.cmmtCnt}</p>
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <TiHeartOutline className="w-5 h-5 text-gray-400" />
+                          <p className="text-gray-500"> {community.likesCnt}</p>
+                        </div>
+                      </div>
+                    </div>
 
                     {/* 오른쪽 */}
                     {/* <div className="flex flex-col items-center w-24 flex-shrink-0"> */}
@@ -236,53 +327,10 @@ export default function Home({content}: {content: string}) {
                       {/* </div> */}
                     </div>
                   </div>
-                </Link>
+                {/* </Link> */}
               </div>
             </div>
           ))}
-        </div>
-      </section>
-
-      <section className="flex flex-col w-full pb-8">
-        <div className="flex flex-row px-4 py-2 justify-between">
-          <h2 className="pl-2 text-heading_2 text-gray-900">New 커뮤니티 글</h2>
-          <Link href="/lessons" className="flex">
-            <ArrowRightIcon className="w-6 h-6 text-gray-900" />
-          </Link>
-        </div>
-        {/* 카드리스트 */}
-        <div className="grid grid-cols-2 gap-6 px-8 py-1">
-          {/* 카드 1*/}
-          <div className="p-6 rounded-lg shadow-sm bg-gray-100 flex flex-col h-full">
-            <div className="flex gap-2 items-center pb-2">
-              <LessonChip label="고급" />
-              <LessonChip label="접영" />
-            </div>
-            <h4 className="pb-10 text-xl font-bold text-gray-900 mb-1">
-              마스터즈 평일 교정 훈련 클래스 가나다
-            </h4>
-            {/* <p className="text-md text-gray-700">수달상회</p> */}
-            <div className="mt-auto">
-              <InstructorProfile avatar="" name="수달상회" />
-            </div>
-          </div>
-
-          {/* 카드 2*/}
-          <div className="p-6 rounded-lg shadow-sm bg-gray-100 flex flex-col h-full">
-            <div className="flex gap-2 items-center pb-2">
-              <LessonChip label="초급" />
-              <LessonChip label="접영" />
-              <LessonChip label="다이빙" />
-              {/* <span className="bg-pink-100 text-pink-500 text-xs font-bold px-2 py-1 rounded">접영</span> */}
-            </div>
-            <h3 className="pb-10 text-xl font-bold text-gray-900 mb-1">
-              유소년 선수반
-            </h3>
-            <div className="mt-auto">
-              <InstructorProfile avatar="" name="이지스윔" />
-            </div>
-            {/* <p className="text-md text-gray-700">수달상회</p> */}
-          </div>
         </div>
       </section>
 
@@ -296,40 +344,88 @@ export default function Home({content}: {content: string}) {
           </Link>
         </div>
         {/* 카드리스트 */}
-        <div className="grid grid-cols-2 gap-6 px-8 py-1">
-          {/* 카드 1*/}
-          <div className="p-6 rounded-lg shadow-sm bg-gray-100 flex flex-col h-full">
-            <div className="flex gap-2 items-center pb-2">
-              <LessonChip label="고급" />
-              <LessonChip label="접영" />
-            </div>
-            <h4 className="pb-10 text-xl font-bold text-gray-900 mb-1">
-              마스터즈 평일 교정 훈련 클래스 가나다
-            </h4>
-            {/* <p className="text-md text-gray-700">수달상회</p> */}
-            <div className="mt-auto">
-              <InstructorProfile avatar="" name="수달상회" />
-            </div>
-          </div>
+        <div className="flex flex-wrap gap-6 px-8 py-1">
+          {swimContests.map((contest) => (
+            <div
+              key={contest.id}
+              className="px-4 py-2 rounded-lg shadow-sm bg-gray-100 w-full"
+            >
+              {/* 카드 1*/}
+              <div className="items-center gap-2 pb-2">
+                {/* <Link
+                  href={`/community/posts/${community.id}`}
+                  className=""
+                > */}
+                  {/* 박스 내용물 하나 */}
+                  <div className="flex flex-row justify-between items-start w-full rounded-lg px-2">
+                    {/* 왼쪽 */}
+                    <div className="flex-1 min-w-0 max-w-[80%] flex flex-col items-start gap-1.5 overflow-hidden">
+                      {/* 여기가 태그/인기 */}
+                      <div
+                        className={`text-label_sb px-1.5 py-1 mt-4 rounded bg-chip-1 text-chip-1-foreground inline-block w-fit`}
+                      >
+                        <p>{contest.categoryName || "\u00A0"}</p>
+                      </div>
+                      <div className="flex flex-col gap-0.5">
+                        <h3 className="text-gray-900 text-body_bb">
+                          {/* {community.communityTitle} */}
+                          {contest.title}
+                        </h3>
+                      </div>
+                        {/* <p className="text-body_b text-gray-600 block truncate xs:max-w-[100px] sm:max-w-[200px] md:max-w-[300px] lg:max-w-[400px] "> */}
+                      <div className="flex items-center gap-1 overflow-hidden min-w-0">
+                        <p className="text-body_b text-gray-600 block truncate w-full">
+                          {contest.period.length > maxLength ? `${contest.period.substring(0, maxLength)}...`
+                          : contest.period}
+                        </p>
+                      </div>
 
-          {/* 카드 2*/}
-          <div className="p-6 rounded-lg shadow-sm bg-gray-100 flex flex-col h-full">
-            <div className="flex gap-2 items-center pb-2">
-              <LessonChip label="초급" />
-              <LessonChip label="접영" />
-              <LessonChip label="다이빙" />
-              {/* <span className="bg-pink-100 text-pink-500 text-xs font-bold px-2 py-1 rounded">접영</span> */}
+                      {/* <div className="flex items-center gap-1">
+              <WriterProfile
+                avatar={community.writerProfile}
+                name={community.writer}
+              />
+            </div> */}
+
+                      {/* <div className="flex flex-row items-center gap-4">
+                        <div className="flex items-center gap-1">
+                          <LuEye className="w-5 h-5 text-gray-400" />
+                          <p className="text-gray-500"> {community.viewCnt}</p>
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <FiMessageSquare className="w-5 h-5 text-gray-400" />
+                          <p className="text-gray-500">{community.cmmtCnt}</p>
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <TiHeartOutline className="w-5 h-5 text-gray-400" />
+                          <p className="text-gray-500"> {community.likesCnt}</p>
+                        </div>
+                      </div> */}
+                    </div>
+
+                    {/* 오른쪽 */}
+                    {/* <div className="flex flex-col items-center w-24 flex-shrink-0"> */}
+                    <div className="mt-6 items-center flex-shrink-0">
+                      {/* <div className="mt-6 w-24 h-24 overflow-hidden rounded-lg"> */}
+                      <p className="mr-2 font-bold">{contest.dDay}</p>
+                        {/* <img
+                          src={
+                            community.images?.imageUrl ||
+                            "/empty/community_thumbnail.png"
+                          }
+                          alt="썸네일"
+                          className="w-24 h-24 object-cover rounded-lg"
+                        /> */}
+                      {/* </div> */}
+                    </div>
+                  </div>
+                {/* </Link> */}
+              </div>
             </div>
-            <h3 className="pb-10 text-xl font-bold text-gray-900 mb-1">
-              유소년 선수반
-            </h3>
-            <div className="mt-auto">
-              <InstructorProfile avatar="" name="이지스윔" />
-            </div>
-            {/* <p className="text-md text-gray-700">수달상회</p> */}
-          </div>
+          ))}
         </div>
       </section>
+
 
       {/* <ul className="grid grid-cols-2 gap-4 px-4 pb-10"></ul> */}
     </div>

--- a/src/app/pools/page.tsx
+++ b/src/app/pools/page.tsx
@@ -23,7 +23,7 @@ const PoolsPage = async () => {
       <section className="flex flex-col">
         <div className="flex items-center gap-2 pt-6 px-4 pb-5">
           <h2 className="text-heading_2 text-gray-900">수영장</h2>
-          <p className="text-body_lb text-gray-500">{pools.length}</p>
+          {/* <p className="text-body_lb text-gray-500">{pools.length}</p> */}
         </div>
 
         <ul className="grid grid-cols-2 gap-4 px-4 pb-10">

--- a/src/app/search/clientPage.tsx
+++ b/src/app/search/clientPage.tsx
@@ -1,0 +1,85 @@
+"use client";
+import ChatIcon from "@/components/icons/ChatIcon";
+import PoolIcon from "@/components/icons/PoolIcon";
+import SwimHatIcon from "@/components/icons/SwimHatIcon";
+import { SearchResult } from "@/types/search";
+
+export default function ClientSearch({}: {}) {
+  return (
+    <div>
+      {/* <p className="p-4">클라이언트 페이지</p> */}
+      <ul className="list-none px-4">
+      {searchResults.map((result) => (
+          <li className="border-b border-gray-300 pb-4">
+            <div className="flex flex-col items-start bg-white-100 rounded-lg mt-4">
+              <div className="flex flex-row">
+                {getCategoryIcon(result.categoryName)}
+                <div
+                  className={`text-label_sb py-1 rounded text-chip-1-foreground inline-block w-fit`}
+                  >
+                  <p className="pl-2">{result.categoryName}</p>
+                </div>
+              </div>
+              <p className="text-md pl-8">{result.title}</p>
+              <p className="text-sm text-gray-600 pl-8">{result.address}</p>
+            </div>
+          </li>
+      ))}
+      </ul>
+    </div>
+  );
+}
+
+const getCategoryIcon = (categoryName: string) => {
+  switch (categoryName) {
+    case "수영장": return <PoolIcon className="h-6 w-6 text-gray-400" />;
+    case "클래스": return <SwimHatIcon className="h-6 w-6 text-gray-400" />;
+    case "커뮤니티": return <ChatIcon className="h-6 w-6 text-gray-400" />;
+    default: return <div></div>;
+  }
+};
+
+const searchResults: SearchResult[] = [
+  {
+    id: 1,
+    categoryName: "수영장",
+    title: "은평청여울수영장",
+    address: "서울 은평구 통일로 304",
+  },
+  {
+    id: 2,
+    categoryName: "수영장",
+    title: "은평청여울수영장 2",
+    address: "서울 은평구 통일로 304",
+  },
+  {
+    id: 3,
+    categoryName: "클래스",
+    title: "은평 유소년 클래스",
+  },
+  {
+    id: 4,
+    categoryName: "클래스",
+    title: "은평 유소년 클래스스스 마스터즈",
+  },
+  {
+    id: 5,
+    categoryName: "커뮤니티",
+    title: "수영장이 있나요? 은평구에",
+  },
+  {
+    id: 6,
+    categoryName: "커뮤니티",
+    title: "은평구 맛집 추천해주세여",
+  },
+  {
+    id: 7,
+    categoryName: "커뮤니티",
+    title: "은평구 어린이 놀이터 위치 알려주세요",
+  },
+  {
+    id: 8,
+    categoryName: "커뮤니티",
+    title: "은평구에서 열리는 축제 정보 알려주세요",
+  },
+];

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,11 +1,17 @@
 import { SearchIcon } from "lucide-react";
+import Link from "next/link";
+import ArrowLeftIcon from "@/components/icons/ArrowLeftIcon";
+import ClientSearch from "./clientPage";
 
 const SearchPage = async () => {
   return (
     <div className="flex flex-col">
-      <div className="p-4">
-        <h1 className="text-xl font-bold">어떤 강습을 찾고 있나요?</h1>
-      </div>
+        <div className="relative flex items-center justify-between py-1 px-1">
+          <Link href="/" className="flex p-3">
+            <ArrowLeftIcon className="w-6 h-6 text-gray-900" />
+          </Link>
+          <h1 className="absolute left-1/2 transform -translate-x-1/2 text-xl font-bold">통합검색</h1>
+         </div>
 
       <div className="px-4">
         <form className="relative flex border rounded-md overflow-hidden">
@@ -13,16 +19,20 @@ const SearchPage = async () => {
             type="text"
             name="course-search"
             id="course-search"
-            className="flex-1 p-2 rounded-md"
-            placeholder="강습을 검색해보세요"
+            // className="flex-1 p-2 rounded-md"
+            className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+            placeholder="클래스명, 수영장, 커뮤니티 글을 검색해보세요"
           />
           <button
             type="submit"
-            className="flex-none flex items-center justify-center bg-red-100 w-10 h-10"
+            className="flex-none flex items-center justify-center bg-gray-100 w-10 h-10"
           >
             <SearchIcon className="w-5 h-5" />
           </button>
         </form>
+      </div>
+      <div>
+       <ClientSearch></ClientSearch>
       </div>
     </div>
   );

--- a/src/schemas/communities.ts
+++ b/src/schemas/communities.ts
@@ -12,13 +12,14 @@ export const communitySchema = z.object({
   content: z.string(),
   image: imageSchema.nullable(),
   likesCnt: z.number(),
-  cmmtCnt: z.number(),
+  cmmtCnt: z.number().default(0),
+  // cmmtCnt: z.string(),
   viewCnt: z.number(),
   writer: z.string(),
-  writerProfile: z.string().nullable(),
+  writerProfile: z.string().url().nullable(),
   createdAt: z.string(),
-  // isPopular: z.string(),
-  // isPopular: z.boolean(),
+  updatedAt: z.string().nullable(),
+  isPopular: z.boolean(),
 });
 
 // export const postsSchema = z.object({
@@ -53,17 +54,30 @@ export const communityDetailSchema = z.object({
   categoryName: z.string().optional(),
   title: z.string(),
   content: z.string(),
-  images: z.array(imageSchema).max(5), //이미지가 최대 5장 들어감
+  images: z.array(imageSchema).max(5).default([]), //이미지가 최대 5장 들어감
   likesCnt: z.number(),
   viewsCnt: z.number(),
   cmmtCnt: z.number(),
   writer: z.string(),
   writerProfile: z.string().url().nullable(),
   createdAt: z.string(),
+  updatedAt: z.string().nullable(),
   // commentList: z.any(),
   // commentList: z.array(communityDetailCommentSchema),
   commentList: z.array(communityDetailCommentSchema).default([]),
   isLiked: z.boolean(),
-  // isPopular: z.booblean(),
-  isPopular: z.string().nullable(),
+  isPopular: z.boolean(),
+  // isPopular: z.string().nullable(),
+});
+
+//페이징을 위한 추가
+export const communityResponseSchema = z.object({
+  success: z.boolean(),
+  message: z.string().nullable(),
+  data: z.object({
+      posts: z.array(communitySchema),
+      totalPosts:z.number(),
+      hasMore: z.boolean(),
+    }),
+    // data: z.array(communitySchema),
 });

--- a/src/types/community.ts
+++ b/src/types/community.ts
@@ -10,7 +10,8 @@ export type CommunitiesProps = {
   writer: string;
   writerProfile: string | null;
   createdAt: string;
-  // isPopular: boolean;
+  updatedAt: string | null;
+  isPopular: boolean;
 };
 
 export type CommunityProps = {
@@ -22,13 +23,15 @@ export type CommunityProps = {
   likesCnt: number;
   viewsCnt: number;
   cmmtCnt: number;
+  // cmmtCnt: string;
   writer: string;
   writerProfile: string | null;
   createdAt: string;
+  updatedAt: string | null;
   commentList: CommentProps[];
   // commentList: [];
   isLiked: boolean;
-  // isPopular: boolean;
+  isPopular: boolean;
 };
 
 export type CommentProps = {
@@ -41,4 +44,18 @@ export type CommentProps = {
   writerProfile: string;
   likeCnt: number;
   createdAt: string;
+};
+
+//추가
+export type communityResponseProps = {
+  success: boolean;
+  message: string | null;
+  data: communityResponseDetailProps[];
+};
+
+//추가
+export type communityResponseDetailProps = {
+  posts: CommunitiesProps[];
+  totalPosts: number;
+  hasMore: boolean;
 };

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -1,0 +1,7 @@
+export type SearchResult = {
+  id: number;
+  categoryName: string;
+  title: string;
+  address?: string;
+  // icon?: React.ReactNode;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -100,6 +100,7 @@ const config: Config = {
       addUtilities(newUtilities);
     }),
     require("tailwindcss-animate"),
+    require('@tailwindcss/line-clamp'),
   ],
 };
 export default config;


### PR DESCRIPTION
**Fix: 커뮤니티 게시판의 카테고리 표시 유무 결정 및 CSS 수정
Feat: 홈 화면 및 검색 화면 개발**
-
***[fix]***
- category chip숨기려 했으나 ux문제로 보류하고 community의 categoryName(Chip) 전부 다 보이게 변경
- 페이징 관련해서 커뮤니티 전체 데이터 zod 및 type 수정, 추가
- 페이징 관련하여 수정한 type과 server와의 api연결을 위해 수정
- 전체 게시글 수 안보이게 lessons/pools/communities 페이지에서 관련부분 삭제
- community create페이지에서 뒤로가기 버튼 누르면 community list페이지로 이동하도록 변경된 경로 수정

***[feat]***
- bottomNav에 home 버튼 추가
- home화면 전체 틀 잡기 검색박스+하단 내용(클래스2/커뮤니티2/대회)
- 인기있는 수영 클래스 부분 생성/CSS 수정(제목 제한 20자?)
- 커뮤니티 부분 가로 너비에 따라 커뮤니티 게시판에서 보여지는 content 글자수 조절
- 검색박스 클릭시 통합검색 페이지로 이동 +  통합검색 페이지 예시화면 작업
