### PR TITLE
Refactor: 내부 API fetch 제거 및 mock 구조 안정화

### DIFF
--- a/src/api/server/community.ts
+++ b/src/api/server/community.ts
@@ -1,39 +1,39 @@
 "use server";
 
+import { buildCommunityList } from "@/lib/community/mockCommunityList.ts";
 import {
   communityDetailSchema,
-  communityResponseSchema,
-  communitySchema,
 } from "@/schemas/communities";
 import { CommunityProps } from "@/types/community";
 
-export const getCommunities = async (
-  category: string = "none",
-  page: string = "0"
-) => {
+export const getCommunities = ( category: string = "none", page: string = "0" ) => {
   try {
     //Mock(route handler)
-    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
-    const url = `${baseUrl}/api/community/posts/list/${category}/${page}`;
+    // const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+    // const url = `${baseUrl}/api/community/posts/list/${category}/${page}`;
+    const res =  buildCommunityList(category, Number(page));
+
+    // const res = await fetch(url, {cache: "no-store"}); //캐시끄기
     //기존
     // const url = `https://api.dive-in.co.kr/community/posts/list/${category}/${page}`;
-    const response = await fetch(url);
+    // const response = await fetch(url);
+    // if (!response.ok) {
+    //   throw new Error(`HTTP에러 상태 코드: ${response.status}`);
+    // }
+    // const body = await response.json();
 
-    if (!response.ok) {
-      throw new Error(`HTTP에러 상태 코드: ${response.status}`);
-    }
+    const body = res.data;
+      console.log("[getCommunities] body keys::", Object.keys(body));
 
-    const body = await response.json();
-    // console.log("::::::::::Fetched Data:", body);
-
-    const validateData = communityResponseSchema.parse(body);
+    // const validateData = communityResponseSchema.parse(body);
     // console.log("::::::::::zod후 Data:", JSON.stringify(validateData, null, 2));
     // const validateData = communitySchema.array().parse(body.data);
-
     // console.log("::::::::::validateData.data는?:", validateData.data);
-    return validateData.data;
+    // return validateData.data;
+    return body;
+
   } catch (error) {
-    console.error(error);
+    console.error("[getCommunities] error::", error);
     // return [];
     return { posts: [], totalPosts: 0, hasMore: false }; //아 여기 반환값 달라서 에러났던 거였음? 하...참나
   }

--- a/src/app/api/community/posts/list/[category]/[page]/route.ts
+++ b/src/app/api/community/posts/list/[category]/[page]/route.ts
@@ -1,38 +1,14 @@
+import { buildCommunityList } from "@/lib/community/mockCommunityList.ts";
 import { NextResponse } from "next/server";
 
 export async function GET(
   _req: Request,
-  { params }: { params: { category: string; page: string } }
+  { params }: { params: { category: string; page: string } },
 ) {
   const { category, page } = params;
   const p = Number(page ?? 0);
-  const pageSize = 10;
-  const totalPosts = 35;
 
-  const posts = Array.from({ length: pageSize }, (_, i) => {
-    const id = p * pageSize + i + 1;
-    return {
-      postId: id,
-      categoryName: String(category),
-      title: `Mock title ${id}`,
-      content: `Mock content ${id}`,
-      image: null,
-      likesCnt: 0,
-      cmntCnt: 0,
-      viewCnt: 0,
-      writer: "Mock Writer",
-      writerProfile: null,
-      createdAt: "2026-01-01 00:00:00",
-      updatedAt: null,
-      isPopular: false,
-    };
-  });
+  const result = buildCommunityList(category, p);
 
-  const hasMore = (p + 1) * pageSize < totalPosts;
-
-  return NextResponse.json({
-    success: true,
-    message: null,
-    data: { posts, totalPosts, hasMore },
-  });
+  return NextResponse.json(result);
 }

--- a/src/lib/community/mockCommunityList.ts.ts
+++ b/src/lib/community/mockCommunityList.ts.ts
@@ -1,0 +1,43 @@
+import { communityResponseSchema } from "@/schemas/communities";
+
+export function buildCommunityList(category: string, page: number) {
+  const pageSize = 10;
+  const totalPosts = 35;
+
+  const posts = Array.from({ length: pageSize }, (_, i) => {
+    const id = page * pageSize + i + 1;
+    return {
+      postId: id,
+      categoryName: String(category),
+      title: `Mock title ${id}`,
+      content: `Mock content ${id}`,
+      image: null,
+      likesCnt: 0,
+      cmntCnt: 0,
+      viewCnt: 0,
+      writer: "Mock Writer",
+      writerProfile: null,
+      createdAt: "2026-01-01 00:00:00",
+      updatedAt: null,
+      isPopular: false,
+    };
+  });
+
+  const hasMore = (page + 1) * pageSize < totalPosts;
+
+  // ✅ Route Handler와 Server Function 모두 동일한 스키마로 검증
+  const body = {
+    success: true,
+    message: null,
+    data: { posts, totalPosts, hasMore },
+  };
+
+  const parsed = communityResponseSchema.safeParse(body);
+  if (!parsed.success) {
+    // 여기서 터지면 mock 자체가 스키마와 불일치
+    console.error("[buildCommunityList] ZodError:", parsed.error.flatten());
+    throw new Error("Mock response schema mismatch");
+  }
+
+  return parsed.data; // { success, message, data: { posts, totalPosts, hasMore } }
+}


### PR DESCRIPTION
**내부 API 호출 제거 및 mock 구조 안정화(Refactor)**
-

<h3>[문제]</h3>

 - 서버 내부에서 동일 서버의 API를 HTTP로 재호출하는 구조로 설계
 - 이 방식은 Preview/Production 환경변수에 의존하며, 도메인 변경 시 데이터 요청이 쉽게 깨질 수 있다는 리스크가 존재함
 - 네트워크 레이어가 불필요하게 추가되어 지연 및 실패 가능성이 증가

<h3>[작업 내용]</h3>

- Mock 데이터 생성 로직을 lib/community의 공용 함수로 분리
- Route Handler와 Server Action에서 해당 함수를 직접 호출하도록 리팩토링
- 내부 HTTP fetch 제거 및 baseUrl 의존성 제거

<h3>[결과 및 개선]</h3>

- 환경 변수 및 도메인 의존성 제거
- 네트워크 레이어 제거로 구조 단순화
- 디버깅 포인트 축소
- Mock과 API 응답 구조의 단일화

<h3>[검증]</h3>

- Community List 페이지에서 무한 스크롤 정상 동작 확인
- Route Handler와 Server Action 모두 동일 데이터 구조 반환 확인
- 로컬 및 Vercel 환경에서 데이터 정상 렌더링 확인

</br> 

<h3>[할 일]</h3> 

- [ ] Detail Route Handler + 화면 정상화
- [ ] Home Route Handler + 첫 화면 정상화
- [ ] Search Route Handler(query 기반) + 타이핑 데모 가능하게
- [ ] (여유 있으면) Create POST Route Handler로 “연동 시뮬레이션