### PR TITLE
Refactor: 커뮤니티 기능을 백엔드와 분리하고 mock 기반 구조로 전환

### DIFF
--- a/src/api/server/community.ts
+++ b/src/api/server/community.ts
@@ -7,7 +7,7 @@ import {
 } from "@/schemas/communities";
 import { CommunityProps, communityResponseDetailProps } from "@/types/community";
 
-export const getCommunities = async( category: string = "none", page: string = "0" ): Promise<communityResponseDetailProps|null>  => {
+export const getCommunities = async( category: string = "none", page: string = "0" ): Promise<communityResponseDetailProps>  => {
   try {
     //Mock(route handler)
     // const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";

--- a/src/api/server/community/index.ts
+++ b/src/api/server/community/index.ts
@@ -1,0 +1,21 @@
+import * as mock from "./mock";
+import * as real from "./real";
+
+const useMock = process.env.USE_MOCK === "true";
+
+export const getCommunities = useMock? mock.getCommunities : real.getCommunities;
+export const getCommunity = useMock? mock.getCommunity : real.getCommunity;
+export const getComments = useMock? mock.getComments : real.getComments;
+
+
+// export const createCommunity = useMock ? mock.createCommunity : real.createCommunity;
+// export const updateCommunity = useMock ? mock.updateCommunity : real.updateCommunity;
+// export const deleteCommunity = useMock ? mock.deleteCommunity : real.deleteCommunity;
+
+// export const createComment = useMock ? mock.createComment : real.createComment;
+
+// export const addLikePost = useMock ? mock.addLikePost : real.addLikePost;
+// export const deleteLikePost = useMock ? mock.deleteLikePost : real.deleteLikePost;
+
+// export const getOG = useMock ? mock.getOG : real.getOG;
+// export const openGraph = useMock ? mock.openGraph : real.openGraph;

--- a/src/api/server/community/mock.ts
+++ b/src/api/server/community/mock.ts
@@ -2,9 +2,6 @@
 
 import { buildCommunityDetail } from "@/lib/community/mockCommunityDetail";
 import { buildCommunityList } from "@/lib/community/mockCommunityList";
-import {
-  communityDetailSchema,
-} from "@/schemas/communities";
 import { CommunityProps, communityResponseDetailProps } from "@/types/community";
 
 export const getCommunities = async( category: string = "none", page: string = "0" ): Promise<communityResponseDetailProps>  => {
@@ -13,74 +10,24 @@ export const getCommunities = async( category: string = "none", page: string = "
     // const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
     // const url = `${baseUrl}/api/community/posts/list/${category}/${page}`;
     const res =  buildCommunityList(category, Number(page));
-
-    // const res = await fetch(url, {cache: "no-store"}); //캐시끄기
-    //기존
-    // const url = `https://api.dive-in.co.kr/community/posts/list/${category}/${page}`;
-    // const response = await fetch(url);
-    // if (!response.ok) {
-    //   throw new Error(`HTTP에러 상태 코드: ${response.status}`);
-    // }
-    // const body = await response.json();
-
     const body = res.data;
-      console.log("[getCommunities] body keys::", Object.keys(body));
+    console.log("[getCommunities] body keys::", Object.keys(body));
 
-    // const validateData = communityResponseSchema.parse(body);
-    // console.log("::::::::::zod후 Data:", JSON.stringify(validateData, null, 2));
-    // const validateData = communitySchema.array().parse(body.data);
-    // console.log("::::::::::validateData.data는?:", validateData.data);
-    // return validateData.data;
     return body;
 
   } catch (error) {
     console.error("[getCommunities] error::", error);
-    // return [];
-    return { posts: [], totalPosts: 0, hasMore: false }; //아 여기 반환값 달라서 에러났던 거였음? 하...참나
+    throw error;
+    // return { posts: [], totalPosts: 0, hasMore: false }; //아 여기 반환값 달라서 에러났던 거였음? 하...참나
   }
 };
 
 // export const getCommunity = async (postId: string): Promise<CommunityProps | null> => {
 export const getCommunity = async (postId: string): Promise<CommunityProps|null> => {
   try {
-    // const response = await fetch(
-    //   `https://api.dive-in.co.kr/community/posts/${postId}`,
-    //   {
-    //     method: "GET",
-    //     headers: {
-    //       "Cache-Control": "no-cache", //캐싱 방지
-    //       "Content-Type": "application/json",
-    //     },
-    //   }
-    // );
     const res = buildCommunityDetail(Number(postId));
-    // console.warn("API 요청 URL:", `https://api.dive-in.co.kr/community/posts/${postId}`);
-    // console.warn("response:", response);
-    // if (!response.ok) {
-    //   throw new Error(`HTTP에러 상태 코드: ${response.status}`);
-    // }
-
     const body = res;
-    // const body = await response.json();
     console.log("API 응답 데이터:", body);
-    // console.log("commentList 데이터:::", body.data?.commentList);
-
-    // const validateData = communityDetailSchema.safeParse(body.data);
-    // if (!validateData.success) {
-    //   console.error("zod 검증 실패::::", validateData.error);
-    // } else {
-    //   console.log("zod 검증 성공::::", validateData.data);
-    // }
-    // console.log("zod 검증된 데이터:::", validateData);
-    // return validateData;
-
-    // 이미지&댓글 처리
-    // const transformedData: CommunityProps = {
-    //   ...body.data,
-    //   commentList: body.data.commentList || [],
-    //   images: body.data.images || [],
-    // };
-    // return transformedData;
 
     return {
       ...body,

--- a/src/api/server/community/real.ts
+++ b/src/api/server/community/real.ts
@@ -1,0 +1,313 @@
+"use server";
+
+import {
+  communityDetailSchema,
+  communityResponseSchema,
+} from "@/schemas/communities";
+import { CommunityProps, communityResponseDetailProps } from "@/types/community";
+
+export const getCommunities = async( category: string = "none", page: string = "0" ): Promise<communityResponseDetailProps>  => {
+  try {
+    //기존
+    const url = `https://api.dive-in.co.kr/community/posts/list/${category}/${page}`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`HTTP에러 상태 코드: ${response.status}`);
+    }
+    const body = await response.json();
+
+    const validateData = communityResponseSchema.parse(body);
+    // console.log("::::::::::zod후 Data:", JSON.stringify(validateData, null, 2));
+    return validateData.data;
+
+  } catch (error) {
+    console.error("[getCommunities] error::", error);
+      console.error("[getCommunities] error::", error);
+      throw error;
+    // return { posts: [], totalPosts: 0, hasMore: false }; //아 여기 반환값 달라서 에러났던 거였음? 하...참나
+  }
+};
+
+export const getCommunity = async (postId: string): Promise<CommunityProps|null> => {
+  try {
+    const response = await fetch(
+      `https://api.dive-in.co.kr/community/posts/${postId}`,
+      {
+        method: "GET",
+        headers: {
+          "Cache-Control": "no-cache", //캐싱 방지
+          "Content-Type": "application/json",
+        },
+      }
+    );
+    console.warn("API 요청 URL:", `https://api.dive-in.co.kr/community/posts/${postId}`);
+    console.warn("response:", response);
+
+    if (!response.ok) {
+      throw new Error(`HTTP에러 상태 코드: ${response.status}`);
+    }
+
+    const body = await response.json();
+    console.log("API 응답 데이터:", body);
+
+    const validateData = communityDetailSchema.safeParse(body.data);
+    if (!validateData.success) {
+      console.error("zod 검증 실패::::", validateData.error);
+    } else {
+      console.log("zod 검증 성공::::", validateData.data);
+    }
+    console.log("zod 검증된 데이터:::", validateData);
+    // return validateData;
+
+    // 이미지&댓글 처리
+    const transformedData: CommunityProps = {
+      ...body.data,
+      commentList: body.data.commentList || [],
+      images: body.data.images || [],
+    };
+    return transformedData;
+  } catch (error) {
+    console.error("[getCommunity] error::", error);
+    return null;
+  }
+};
+
+export const createCommunity = async (formData: FormData) => {
+  try {
+    const response = await fetch("https://api.dive-in.co.kr/community/posts", {
+      method: "POST",
+      body: formData,
+      headers: {
+        Accept: "application/json",
+      },
+    });
+
+    if (!response) {
+      throw new Error("게시글 작성 실패!");
+    }
+
+    const result = await response.json();
+    console.log("글 작성 성공:", result);
+    if (result?.success && result?.data?.postId) {
+      return result.data.postId;
+    } else {
+      throw new Error("postId를 반환하지 않았습니다.");
+    }
+  } catch (error) {
+    console.log("글 작성 실패:", error);
+    throw error;
+  }
+};
+
+export const updateCommunity = async (postId: string, formData: FormData) => {
+  try {
+    console.warn("FormData 확인:", Array.from(formData.entries())); // 디버깅
+    const response = await fetch(
+      `https://api.dive-in.co.kr/community/posts/${postId}`,
+      {
+        method: "PUT",
+        body: formData,
+        headers: {
+          // Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+      }
+    );
+
+    if (!response) {
+      throw new Error("게시글 수정 실패!");
+    }
+
+    const result = await response.json();
+    console.log("글 수정 성공:", result);
+  } catch (error) {
+    console.log("글 수정 실패:", error);
+    throw error;
+  }
+};
+
+export const deleteCommunity = async (id: string, memberId: string) => {
+  try {
+    const response = await fetch(
+      `https://api.dive-in.co.kr/community/posts/${id}?memberId=${memberId}`,
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+
+    if (!response) {
+      throw new Error("게시글 삭제 실패!");
+    }
+    // console.warn("API 요청 URL:", `https://api.dive-in.co.kr/community/posts/${id}`);
+    console.log("게시글이 삭제 성공!");
+    return true;
+  } catch (error) {
+    console.log(error);
+    return false;
+  }
+};
+
+export const getOG = async (link: string) => {
+  try {
+    const response = await fetch("/api/shorten-link", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: link }),
+    });
+
+    const result = await response.json();
+    return result;
+  } catch (error) {
+    console.log(error);
+    return [];
+  }
+};
+
+// 댓글
+// export const getComments = async () => {
+//   try {
+//     const response = await fetch("https://api.dive-in.co.kr/community/comments");
+//     const body = await response.json();
+//   } catch (error) {
+//     console.log(error);
+//     return [];
+//   }
+// };
+
+export const getComments = async (postId: number) => {
+  try {
+    const response = await fetch(
+      `https://api.dive-in.co.kr/community/comments/${postId}`
+    );
+    const body = await response.json();
+
+    return body;
+  } catch (error) {
+    console.log(error);
+    return [];
+  }
+};
+
+export const createComment = async (formData: FormData) => {
+  try {
+    const response = await fetch(
+      "https://api.dive-in.co.kr/community/comments",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(formData),
+      }
+    );
+
+    if (!response) {
+      throw new Error("게시글 작성 실패!");
+    }
+
+    const result = await response.json();
+    console.log("댓글 작성 성공:", result);
+  } catch (error) {
+    console.log("댓글 작성 실패:", error);
+    return [];
+  }
+};
+
+// export const updateComments = async() => {
+//   try {
+//     const response = await fetch("https://api.dive-in.co.kr/community/comments");
+//     const body = await response.json();
+//   } catch (error) {
+//     console.log(error);
+//     return [];
+//   }
+// };
+
+// export const deleteComments = async() => {
+//   try {
+//     const response = await fetch("https://api.dive-in.co.kr/community/comments");
+//     const body = await response.json();
+//   } catch (error) {
+//     console.log(error);
+//     return [];
+//   }
+// };
+
+export const addLikePost = async (postId: string, memberId: string) => {
+  // const user = parseInt(memberId);
+  try {
+    const response = await fetch(
+      `https://api.dive-in.co.kr/community/posts/${postId}/like?memberId=${memberId}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Cache-Control": "no-cache", //캐싱 방지
+        },
+      }
+    );
+
+    console.log("Response status:", response.status);
+    // console.log("Response body:", await response.text());
+
+    if (!response.ok) {
+      throw new Error("좋아요 실패!");
+    }
+    const body = await response.json();
+    console.log("좋아요 성공:", body);
+    return body;
+  } catch (error) {
+    console.log(error);
+    return [];
+  }
+};
+
+export const deleteLikePost = async (postId: string, memberId: string) => {
+  // const user = parseInt(memberId);
+  try {
+    const response = await fetch(
+      `https://api.dive-in.co.kr/community/posts/${postId}/like?memberId=${memberId}`,
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          "Cache-Control": "no-cache", //캐싱 방지
+        },
+      }
+    );
+
+    console.log("Response status:", response.status);
+    // console.log("Response body:", await response.text());
+
+    if (!response.ok) {
+      const errorMessage = `좋아요 취소 실패: HTTP ${response.status}`;
+      console.error(errorMessage);
+      throw new Error("좋아요 취소 실패!");
+    }
+    const body = await response.json();
+    console.log("좋아요 취소 성공:", body);
+    return body;
+  } catch (error) {
+    console.log(error);
+    return [];
+  }
+};
+
+export const openGraph = async (url: string) => {
+  try {
+    console.log(":::url이 서버로 넘어가는중:", url);
+
+    const response = await fetch(
+      `https://api.dive-in.co.kr/api/openGraph/fetch?url=${url}`
+    );
+    const body = await response.json();
+
+    return body;
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
+};

--- a/src/app/api/community/posts/[id]/route.ts
+++ b/src/app/api/community/posts/[id]/route.ts
@@ -3,10 +3,10 @@ import { NextResponse } from "next/server";
 
 export async function GET(
   _req: Request,
-  { params }: { params: { postId: string } },
+  { params }: { params: { id: string } },
 ) {
   try {
-    const postId = Number(params.postId);
+    const postId = Number(params.id);
     const result = buildCommunityDetail(postId);
 
     return NextResponse.json({

--- a/src/app/api/community/posts/list/[category]/[page]/route.ts
+++ b/src/app/api/community/posts/list/[category]/[page]/route.ts
@@ -12,7 +12,7 @@ export async function GET(
 
     const data = buildCommunityList(category, page);
 
-    return NextResponse.json({ success: true, message: null, data });
+    return NextResponse.json(data);
   } catch (error) {
     console.error("[list route] error::", error);
     return NextResponse.json(

--- a/src/app/community/_components/CategoryFilter.tsx
+++ b/src/app/community/_components/CategoryFilter.tsx
@@ -128,8 +128,8 @@ export default function CategoryFilter({
             } */}
 
             <span className="mt-3 text-b text-gray-500 ml-auto">
-              {/* {community.createdAt.split(" ")[0].slice(2)} */}
-              {community.createdAt.slice(2, 12)}
+              {community.createdAt.split(" ")[0]}
+              {/* {community.createdAt.slice(0, 11)} */}
             </span>
           </div>
         </div>

--- a/src/app/community/_components/CommentList.tsx
+++ b/src/app/community/_components/CommentList.tsx
@@ -3,21 +3,7 @@
 import { useEffect, useState } from "react";
 import { Comment } from "../comments/Comment";
 import { getComments } from "@/api/server/community";
-
-// import { CommentProps } from "@/types/community";
-
-interface CommentProps {
-  postId?: number;
-  cmntId: number;
-  content: string;
-  groupName?: number;
-  orderNumber?: number;
-  cmntClass?: number;
-  writer: string;
-  writerProfile: string;
-  likeCnt?: number;
-  createdAt: string;
-}
+import { CommentProps } from "@/types/community";
 
 export default function CommentList({
   commentList,
@@ -82,7 +68,7 @@ export default function CommentList({
       {commentList.map((comment) => (
         <Comment
           key={comment.cmntId}
-          cmmtId={comment.cmntId}
+          cmntId={comment.cmntId}
           content={comment.content}
           groupName={comment.groupName}
           orderNumber={comment.orderNumber}

--- a/src/app/community/_components/CommentList.tsx
+++ b/src/app/community/_components/CommentList.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Comment } from "../comments/Comment";
-import { getComments } from "@/api/server/community";
+import { getComments } from "@/api/server/community/mock";
 import { CommentProps } from "@/types/community";
 
 export default function CommentList({

--- a/src/app/community/_components/FloatingButton.tsx
+++ b/src/app/community/_components/FloatingButton.tsx
@@ -1,16 +1,19 @@
 import Link from "next/link";
 
-export default function FloatingButton(){
+export default function FloatingButton() {
   return (
-    <div>
-      <Link
-        href="/community/posts"
-        className="fixed bottom-20 right-4 w-20 h-20 bg-blue-900 text-white rounded-full 
+    <div className="fixed bottom-20 left-20 right-0 z-50 pointer-events-none">
+      <div className="max-w-3xl w-full mx-auto flex justify-end px-4">
+        <Link
+          href="/community/posts"
+          className="pointer-events-auto w-20 h-20 bg-blue-900 text-white rounded-full 
         flex items-center justify-center shadow-lg hover:bg-blue-800"
-      >
-        <p className="text-4xl leading-none relative top-[-2px] hover:scale-110 transition-transform">+</p>
-      </Link>
-
+        >
+          <p className="text-4xl leading-none relative top-[-2px] hover:scale-110 transition-transform">
+            +
+          </p>
+        </Link>
+      </div>
     </div>
   );
 }

--- a/src/app/community/comments/Comment.tsx
+++ b/src/app/community/comments/Comment.tsx
@@ -4,7 +4,7 @@
 //   return <div>댓글 페이지</div>;
 // }
 
-import { getComments } from "@/api/server/community";
+import { getComments } from "@/api/server/community/mock";
 import { getUser } from "@/actions/user";
 import { RiShare2Line } from "react-icons/ri";
 import WriterProfile from "../_components/WriterProfile";

--- a/src/app/community/comments/Comment.tsx
+++ b/src/app/community/comments/Comment.tsx
@@ -12,28 +12,10 @@ import { VscKebabVertical } from "react-icons/vsc";
 import { useEffect, useState } from "react";
 import { GoPencil } from "react-icons/go";
 import { GoTrash } from "react-icons/go";
-// import { CommentProps } from "@/types/community";
-
-interface CommentProps {
-  // writerId: number;
-  // loggedUserId: number | null;
-  cmmtId: number;
-  content: string;
-  groupName?: number;
-  orderNumber?: number;
-  cmntClass?: number;
-  writer: string;
-  writerProfile: string;
-  likeCnt?: number;
-  createdAt: string;
-}
-
-// interface CommentsProps {
-//   commentList: CommentProps[];
-// }
+import { CommentProps } from "@/types/community";
 
 export const Comment = ({
-  cmmtId,
+  cmntId,
   content,
   groupName,
   orderNumber,
@@ -57,7 +39,7 @@ export const Comment = ({
   };
 
   return (
-    <div key={cmmtId} className="py-3">
+    <div key={cmntId} className="py-3">
       {/* 작성자 */}
       <div className="flex flex-row items-start px-4">
         <WriterProfile

--- a/src/app/community/posts/[id]/clientPage.tsx
+++ b/src/app/community/posts/[id]/clientPage.tsx
@@ -19,7 +19,7 @@ import {
   deleteLikePost,
   getCommunity,
   openGraph,
-} from "@/api/server/community";
+} from "@/api/server/community/mock";
 import DetailPagePhotoSlider from "@/app/_components/PhotoSlider";
 import CommentList from "../../_components/CommentList";
 

--- a/src/app/community/posts/[id]/edit/page.tsx
+++ b/src/app/community/posts/[id]/edit/page.tsx
@@ -12,7 +12,7 @@ import {
   getCommunity,
   openGraph,
   updateCommunity,
-} from "@/api/server/community";
+} from "@/api/server/community/mock";
 import { useRouter } from "next/navigation";
 import OpenGraphPreview from "@/app/_components/OpenGraphLinkReview";
 

--- a/src/app/community/posts/[id]/page.tsx
+++ b/src/app/community/posts/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { getCommunity } from "@/api/server/community";
+import { getCommunity } from "@/api/server/community/mock";
 import { notFound } from "next/navigation";
 import ClientCommunityPage from "./clientPage";
 

--- a/src/app/community/posts/list/clientPage.tsx
+++ b/src/app/community/posts/list/clientPage.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import FloatingButton from "../../_components/FloatingButton";
 import CategoryFilter from "@/app/community/_components/CategoryFilter";
-import { getCommunities } from "@/api/server/community";
+import { getCommunities } from "@/api/server/community/mock";
 import { useRouter } from "next/navigation";
 import {
   CommunitiesProps,

--- a/src/app/community/posts/list/clientPage.tsx
+++ b/src/app/community/posts/list/clientPage.tsx
@@ -58,20 +58,21 @@ export default function CommunitiesClient({
         // const page = "0";
         // router.replace(`/community/posts/list?category=${category}&page=${page}`);
         const data = await getCommunities(category, page);
-        if(isCancel) return;
+        if (isCancel) return;
 
         setCommunities(data.posts);
         setHasMore(data.hasMore);
         setCurrentPage(Number(page) || 0);
-
       } catch (error) {
-        console.error("[communityList error]::",error);
-          setHasMore(false);
+        console.error("[communityList error]::", error);
+        setHasMore(false);
       }
     };
 
     fetchData();
-    return () => {isCancel = true};
+    return () => {
+      isCancel = true;
+    };
   }, [category, page]);
 
   //무한스크롤
@@ -83,45 +84,51 @@ export default function CommunitiesClient({
         try {
           const nextPage = currentPage + 1;
           const data = await getCommunities(category, String(nextPage));
-          if(isCancel) return;
+          if (isCancel) return;
 
-        if (data.posts.length > 0) {
-          setCommunities((prev) => [...prev, ...data.posts]);
-          setHasMore(data.hasMore);
-          setCurrentPage(nextPage);
-        } else {
+          if (data.posts.length > 0) {
+            setCommunities((prev) => [...prev, ...data.posts]);
+            setHasMore(data.hasMore);
+            setCurrentPage(nextPage);
+          } else {
+            setHasMore(false);
+          }
+        } catch (error) {
+          if (isCancel) return;
+          console.error("[communityList error]::", error);
           setHasMore(false);
         }
-      } catch (error) {
-        if(isCancel) return;
-        console.error("[communityList error]::",error);
-        setHasMore(false);
-      }
-    };
-    
-    fetchMoreData();
-    return () => { isCancel = true; };
+      };
+
+      fetchMoreData();
+      return () => {
+        isCancel = true;
+      };
     }
   }, [inView, hasMore, currentPage, category]);
 
   return (
     <div>
-      <div className="flex gap-2 mb-4 px-4">
+      {/* <div className="flex gap-2 mb-4 px-4"> */}
+      <div className="mb-4 px-4 grid grid-cols-3 gap-2 md:flex md:flex-nowrap md:gap-2">
         {CATEGORIES.map((c) => (
           <button
             key={c.key}
-            onClick={() =>  router.replace(`/community/posts/list?category=${c.key}&page=0`)}
-            className={`px-4 py-2 rounded-full ${
-              category === c.key
-                ? "bg-gray-300 text-black font-bold"
-                : "bg-gray-100 text-gray-500 font-bold"
-            } 
+            onClick={() =>
+              router.replace(`/community/posts/list?category=${c.key}&page=0`)
+            }
+            className={`w-full md:w-auto px-2 py-1 text-xs md:px-4 md:py-2 md:text-base
+                        rounded-full whitespace-nowrap 
+           ${
+             category === c.key
+               ? "bg-gray-300 text-black font-bold"
+               : "bg-gray-100 text-gray-500 font-bold"
+           } 
               hover:bg-gray-300`}
           >
             {c.name}
           </button>
         ))}
-        
       </div>
 
       {/*로딩 중*/}
@@ -141,7 +148,6 @@ export default function CommunitiesClient({
           // <p className="text-gray-500">해당 커뮤니티가 존재하지 않습니다.</p>
           <p className="text-gray-500"></p>
         )}
-       
       </ul>
       {/* )} */}
       <FloatingButton />

--- a/src/app/community/posts/list/clientPage.tsx
+++ b/src/app/community/posts/list/clientPage.tsx
@@ -6,7 +6,11 @@ import FloatingButton from "../../_components/FloatingButton";
 import CategoryFilter from "@/app/community/_components/CategoryFilter";
 import { getCommunities } from "@/api/server/community";
 import { useRouter } from "next/navigation";
-import { CommunitiesProps, communityResponseDetailProps, communityResponseProps } from "@/types/community";
+import {
+  CommunitiesProps,
+  communityResponseDetailProps,
+  communityResponseProps,
+} from "@/types/community";
 import { CATEGORIES } from "@/constants/categories";
 import { useInView } from "react-intersection-observer";
 
@@ -19,21 +23,27 @@ import { useInView } from "react-intersection-observer";
 //   {name: "수영대회", key: "competition"},
 // ];
 
-export default function CommunitiesClient({ communityList, category, page }:{
+export default function CommunitiesClient({
+  communityList,
+  category,
+  page,
+}: {
   // communityList: CommunitiesProps[];
-    communityList: communityResponseDetailProps;
-    category: string; 
-    page: string;
-    // hasMore: boolean;
-    // totalposts: number;
-  }) {
-  const [selectedCategory, setSelectedCategory] = useState<string>(category); //기본 카테고리
-  const [communities, setCommunities] = useState<CommunitiesProps[]>(communityList.posts); //초기 데이터
-  
+  communityList: communityResponseDetailProps;
+  category: string;
+  page: string;
+  // hasMore: boolean;
+  // totalposts: number;
+}) {
+  // const [selectedCategory, setSelectedCategory] = useState<string>(category); //기본 카테고리
+  const [communities, setCommunities] = useState<CommunitiesProps[]>(
+    communityList.posts,
+  ); //초기 데이터
+
   //무한스크롤 추가
   const [currentPage, setCurrentPage] = useState<number>(Number(page) || 0);
   const [hasMore, setHasMore] = useState<boolean>(communityList.hasMore);
-  const {ref, inView} = useInView({
+  const { ref, inView } = useInView({
     threshold: 0.5, // 요소가 50% 보일 때 inView가 true로 바뀜
   });
 
@@ -42,84 +52,112 @@ export default function CommunitiesClient({ communityList, category, page }:{
   //카테고리 변경시 URL 업데이트
   useEffect(() => {
     //카테고리 변경시 데이터 가져옴
-    const fetchData = async() => {
-      const data: communityResponseDetailProps = await getCommunities(selectedCategory, page);
-      setCommunities(data.posts);
-      setHasMore(data.hasMore);
-      setCurrentPage(0);
+    let isCancel = false;
+    const fetchData = async () => {
+      try {
+        // const page = "0";
+        // router.replace(`/community/posts/list?category=${category}&page=${page}`);
+        const data = await getCommunities(category, page);
+        if(isCancel) return;
+
+        setCommunities(data.posts);
+        setHasMore(data.hasMore);
+        setCurrentPage(Number(page) || 0);
+
+      } catch (error) {
+        console.error("[communityList error]::",error);
+          setHasMore(false);
+      }
     };
 
     fetchData();
-    router.push(`/community/posts/list?category=${selectedCategory}&page=${page}`);
-  },[selectedCategory, page]);
-
+    return () => {isCancel = true};
+  }, [category, page]);
 
   //무한스크롤
-  useEffect(()=> {
-    if(inView && hasMore) {
-      const fetchMoreData = async() => {
-        const nextPage = currentPage + 1;
-        const data: communityResponseDetailProps = await getCommunities(selectedCategory, String(nextPage));
+  useEffect(() => {
+    if (inView && hasMore) {
+      let isCancel = false;
 
-        if(data.posts.length > 0) {
+      const fetchMoreData = async () => {
+        try {
+          const nextPage = currentPage + 1;
+          const data = await getCommunities(category, String(nextPage));
+          if(isCancel) return;
+
+        if (data.posts.length > 0) {
           setCommunities((prev) => [...prev, ...data.posts]);
           setHasMore(data.hasMore);
           setCurrentPage(nextPage);
-        }else{
+        } else {
           setHasMore(false);
         }
-      };
-
-      fetchMoreData();
+      } catch (error) {
+        if(isCancel) return;
+        console.error("[communityList error]::",error);
+        setHasMore(false);
+      }
+    };
+    
+    fetchMoreData();
+    return () => { isCancel = true; };
     }
-  },[inView, hasMore, currentPage, selectedCategory]);
+  }, [inView, hasMore, currentPage, category]);
 
   return (
     <div>
       <div className="flex gap-2 mb-4 px-4">
-        {CATEGORIES.map((category) => (
+        {CATEGORIES.map((c) => (
           <button
-            key={category.key}
-            onClick={() => setSelectedCategory(category.key)}
+            key={c.key}
+            onClick={() =>  router.replace(`/community/posts/list?category=${c.key}&page=0`)}
             className={`px-4 py-2 rounded-full ${
-              selectedCategory === category.key
+              category === c.key
                 ? "bg-gray-300 text-black font-bold"
                 : "bg-gray-100 text-gray-500 font-bold"
             } 
               hover:bg-gray-300`}
           >
-            {category.name}
+            {c.name}
           </button>
         ))}
+        
       </div>
 
-        {/*로딩 중*/}
-        {/* {loading? (
+      {/*로딩 중*/}
+      {/* {loading? (
           <p>로딩 중...</p>
         ) : ( */}
-          <ul className="flex flex-col gap-1 px-4 pb-10">
-          {communities && communities.length > 0 ? (
-            communities.map((community) => (
-              <CategoryFilter key={community.postId} community={community} selectedCategory={selectedCategory} />
-            ))
-          ) : (
-            // <p className="text-gray-500">해당 커뮤니티가 존재하지 않습니다.</p>
-            <p className="text-gray-500"></p>
-          )}
-        </ul>
-        {/* )} */}
-        <FloatingButton />
-
-        {/* 무한스크롤 감지 */}
-        {hasMore? (
-          <div className="flex justify-center pb-8 gap-2">
-            <div className="w-6 h-6 border-4 border-gray-300 border-t-gray-500 rounded-full animate-spin"></div>
-            <div ref={ref} className="text-gray-400">Loading more...</div>
-          </div>
-
+      <ul className="flex flex-col gap-1 px-4 pb-10">
+        {communities && communities.length > 0 ? (
+          communities.map((community) => (
+            <CategoryFilter
+              key={community.postId}
+              community={community}
+              selectedCategory={category}
+            />
+          ))
         ) : (
-          <p className="text-center text-gray-400 pb-8">더 이상 게시물이 없습니다.</p>
+          // <p className="text-gray-500">해당 커뮤니티가 존재하지 않습니다.</p>
+          <p className="text-gray-500"></p>
         )}
+       
+      </ul>
+      {/* )} */}
+      <FloatingButton />
+      {/* 무한스크롤 감지 */}
+      {hasMore ? (
+        <div className="flex justify-center pb-8 gap-2">
+          <div className="w-6 h-6 border-4 border-gray-300 border-t-gray-500 rounded-full animate-spin"></div>
+          <div ref={ref} className="text-gray-400">
+            Loading more...
+          </div>
+        </div>
+      ) : (
+        <p className="text-center text-gray-400 pb-8">
+          더 이상 게시물이 없습니다.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/app/community/posts/list/page.tsx
+++ b/src/app/community/posts/list/page.tsx
@@ -1,4 +1,4 @@
-import { getCommunities } from "@/api/server/community";
+import { getCommunities } from "@/api/server/community/mock";
 import Link from "next/link";
 import Image from "next/image";
 import CommunitiesClient from "./clientPage";

--- a/src/app/community/posts/page.tsx
+++ b/src/app/community/posts/page.tsx
@@ -7,7 +7,7 @@ import { MdOutlineBrokenImage } from "react-icons/md";
 import { AiOutlineLink } from "react-icons/ai";
 import { IoIosArrowDown } from "react-icons/io";
 import { useEffect, useRef, useState } from "react";
-import { createCommunity, openGraph } from "@/api/server/community";
+import { createCommunity, openGraph } from "@/api/server/community/mock";
 import { useRouter } from "next/navigation";
 import OpenGraphPreview from "@/app/_components/OpenGraphLinkReview";
 

--- a/src/types/community.ts
+++ b/src/types/community.ts
@@ -38,6 +38,7 @@ export type CommunityProps = {
 };
 
 export type CommentProps = {
+  postId?: number;
   cmntId: number;
   content: string;
   groupName: number;
@@ -48,6 +49,22 @@ export type CommentProps = {
   likeCnt: number;
   createdAt: string;
 };
+
+
+// interface CommentProps {
+// writerId: number;
+// loggedUserId: number | null;
+//   postId?: number;
+//   cmntId: number;
+//   content: string;
+//   groupName?: number;
+//   orderNumber?: number;
+//   cmntClass?: number;
+//   writer: string;
+//   writerProfile: string;
+//   likeCnt?: number;
+//   createdAt: string;
+// }
 
 //추가
 export type communityResponseProps = {


### PR DESCRIPTION
**mock을 우선으로 사용하는 구조로 커뮤니티 기능을 재설계하여, 독립 배포가 가능하도록 리팩토링**
-

<h3>[배경]</h3>

- 백엔드 이탈로 인해 커뮤니티 기능 검증 및 배포가 불가능한 상태였음.
- 라우팅 불일치, 상태/URL 이중 관리, API 의존 구조 등 구조적 정리가 필요했음.

<h3>[문제]</h3>

- Route param 불일치 ([postId] → [id])
- category/page 상태와 URL의 이중 관리
- 백엔드 의존 구조로 인해 단독 배포 불가
- FloatingButton viewport 기준 고정으로 UI 불안정
<img width="1548" height="533" alt="image" src="https://github.com/user-attachments/assets/a48b4e4d-9df2-435e-a515-719b9e7979c2" />

- 모바일 카테고리 버튼 레이아웃 붕괴
<img width="341" height="739" alt="image" src="https://github.com/user-attachments/assets/df58b620-a246-483e-866b-38102e898a15" />


<h3>[작업 내용]</h3>

<b>1. 라우팅/상태 구조 정리</b>
- Route param postId → id 수정
- selectedCategory state 제거
- URL query를 단일 소스로 통합

<b>2. 데이터 소스 추상화</b>
- mock.ts / real.ts / index.ts 분리
- env 기반 mock/real 런타임 스위칭 도입
- 백엔드 없이도 독립 배포 가능 구조 확보

<b>3. 응답 정합성 유지</b>
- response shape 통일
- Zod 검증 유지
- 에러 처리 정책 throw 기반으로 통일

<b>4. UI 안정화</b>
- FloatingButton을 layout container 기준으로 수정
<img width="1548" height="539" alt="image" src="https://github.com/user-attachments/assets/db79b4a0-1f42-417e-8542-e1435604eff0" />

- 모바일 반응형 버튼 레이아웃 개선
<img width="332" height="790" alt="image" src="https://github.com/user-attachments/assets/d6320612-d18b-4cca-a751-4e60a1be20cd" />

<h3>[결과 및 개선]</h3>

- 커뮤니티 기능 독립 배포 가능
- URL 기반 딥링크 지원
- mock/real 교체 가능한 구조 확보
- 모바일/PC 레이아웃 안정화

<h3>[검증]</h3>

- `/community/posts/list?category=xxx&page=0` 직접 접근 정상 렌더링
- USE_MOCK=true 환경에서 list/detail 정상 동작
- Route param 수정 후 detail 페이지 정상 동작
- 모바일 화면 레이아웃 확인 완료

</br> 

<h3>[할 일]</h3> 

- [x] Detail Route Handler + 화면 정상화
- [ ] Home Route Handler + 첫 화면 정상화
- [ ] Search Route Handler(query 기반) + 타이핑 데모 가능하게
- [ ] (여유 있으면) Create POST Route Handler로 연동