### PR TITLE
Refactor: mock 기반 repo 도입 및 카테고리 도메인 구조 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ next-env.d.ts
 *.sln
 *.sw?
 build.sh
+claude.md

--- a/src/api/server/community/index.ts
+++ b/src/api/server/community/index.ts
@@ -1,12 +1,13 @@
-import * as mock from "./mock.server";
+import * as mockServer from "./mock.server";
+import * as mockClient from "./mock.client";
 import * as real from "./real";
 
 const useMock = process.env.USE_MOCK === "true";
 
-export const getCommunities = useMock? mock.getCommunities : real.getCommunities;
-export const getCommunity = useMock? mock.getCommunity : real.getCommunity;
-export const getComments = useMock? mock.getComments : real.getComments;
-export const createCommunity = useMock ? mock.createCommunity : real.createCommunity;
+export const getCommunities = useMock? mockServer.getCommunities : real.getCommunities;
+export const getCommunity = useMock? mockServer.getCommunity : real.getCommunity;
+export const getComments = useMock? mockServer.getComments : real.getComments;
+export const createCommunity = useMock ? mockClient.createCommunity : real.createCommunity;
 
 
 // export const updateCommunity = useMock ? mock.updateCommunity : real.updateCommunity;

--- a/src/api/server/community/index.ts
+++ b/src/api/server/community/index.ts
@@ -1,4 +1,4 @@
-import * as mock from "./mock";
+import * as mock from "./mock.server";
 import * as real from "./real";
 
 const useMock = process.env.USE_MOCK === "true";
@@ -6,9 +6,9 @@ const useMock = process.env.USE_MOCK === "true";
 export const getCommunities = useMock? mock.getCommunities : real.getCommunities;
 export const getCommunity = useMock? mock.getCommunity : real.getCommunity;
 export const getComments = useMock? mock.getComments : real.getComments;
+export const createCommunity = useMock ? mock.createCommunity : real.createCommunity;
 
 
-// export const createCommunity = useMock ? mock.createCommunity : real.createCommunity;
 // export const updateCommunity = useMock ? mock.updateCommunity : real.updateCommunity;
 // export const deleteCommunity = useMock ? mock.deleteCommunity : real.deleteCommunity;
 

--- a/src/api/server/community/mock.client.ts
+++ b/src/api/server/community/mock.client.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { CATEGORY_NAMES, toCategoryName } from "@/constants/categories";
 import { createPost, ensureSeeded } from "@/lib/community/communityRepo.client";
 import { CommunitiesProps, CommunityProps } from "@/types/community";
 
@@ -14,7 +15,13 @@ export async function createCommunity(formData: FormData): Promise<number> {
     ensureSeeded();
 
     const postId = Date.now();
-    const categoryType = String(formData.get("categoryType") ?? "COMMUNICATION");
+
+    const categoryData = formData.get("categoryType");
+    if((typeof categoryData !== "string") || (!CATEGORY_NAMES.includes(categoryData))){
+      throw new Error("Invalid category type");
+    }
+    const categoryType = toCategoryName(categoryData);
+
     const title = String(formData.get("title") ?? "");
     const content = String(formData.get("content") ?? "");
     const memberId = String(formData.get("memberId") ?? "1");

--- a/src/api/server/community/mock.client.ts
+++ b/src/api/server/community/mock.client.ts
@@ -4,11 +4,6 @@ import { CATEGORY_NAMES, toCategoryName } from "@/constants/categories";
 import { createPost, ensureSeeded } from "@/lib/community/communityRepo.client";
 import { CommunitiesProps, CommunityProps } from "@/types/community";
 
-// export function formatKST(isoString: string) {
-//   return new Date(isoString).toLocaleString("ko-KR", {
-//     timeZone: "Asia/Seoul",
-//   });
-// }
 
 export async function createCommunity(formData: FormData): Promise<number> {
   try {
@@ -17,7 +12,7 @@ export async function createCommunity(formData: FormData): Promise<number> {
     const postId = Date.now();
 
     const categoryData = formData.get("categoryType");
-    if((typeof categoryData !== "string") || (!CATEGORY_NAMES.includes(categoryData))){
+    if((typeof categoryData !== "string") || (!(CATEGORY_NAMES as readonly string[]).includes(categoryData))){
       throw new Error("Invalid category type");
     }
     const categoryType = toCategoryName(categoryData);

--- a/src/api/server/community/mock.client.ts
+++ b/src/api/server/community/mock.client.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { createPost, ensureSeeded } from "@/lib/community/communityRepo.client";
+import { CommunitiesProps, CommunityProps } from "@/types/community";
+
+// export function formatKST(isoString: string) {
+//   return new Date(isoString).toLocaleString("ko-KR", {
+//     timeZone: "Asia/Seoul",
+//   });
+// }
+
+export async function createCommunity(formData: FormData): Promise<number> {
+  try {
+    ensureSeeded();
+
+    const postId = Date.now();
+    const categoryType = String(formData.get("categoryType") ?? "COMMUNICATION");
+    const title = String(formData.get("title") ?? "");
+    const content = String(formData.get("content") ?? "");
+    const memberId = String(formData.get("memberId") ?? "1");
+
+    if (!title.trim()) throw new Error("제목이 비어있습니다.");
+    if (!content.trim()) throw new Error("내용이 비어있습니다.");
+
+    const newPost: CommunityProps = {
+      postId,
+      categoryName: categoryType,
+      title,
+      content,
+      images: [],
+      likesCnt: 0,
+      viewCnt: 0,
+      cmntCnt: 0,
+      writer: `User ${memberId}`,
+      writerProfile: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: null,
+      commentList: [],
+      isLiked: false,
+      isPopular: false,
+    };
+
+    return createPost(newPost);
+
+  } catch (error) {
+    console.log("글 작성 실패:", error);
+    throw error;
+  }
+}

--- a/src/api/server/community/mock.server.ts
+++ b/src/api/server/community/mock.server.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { buildCommunityDetail } from "@/lib/community/mockCommunityDetail";
 import { buildCommunityList } from "@/lib/community/mockCommunityList";
 import { CommunityProps, communityResponseDetailProps } from "@/types/community";
@@ -37,33 +35,6 @@ export const getCommunity = async (postId: string): Promise<CommunityProps|null>
   } catch (error) {
     console.error("[getCommunity] error::", error);
     return null;
-  }
-};
-
-export const createCommunity = async (formData: FormData) => {
-  try {
-    const response = await fetch("https://api.dive-in.co.kr/community/posts", {
-      method: "POST",
-      body: formData,
-      headers: {
-        Accept: "application/json",
-      },
-    });
-
-    if (!response) {
-      throw new Error("게시글 작성 실패!");
-    }
-
-    const result = await response.json();
-    console.log("글 작성 성공:", result);
-    if (result?.success && result?.data?.postId) {
-      return result.data.postId;
-    } else {
-      throw new Error("postId를 반환하지 않았습니다.");
-    }
-  } catch (error) {
-    console.log("글 작성 실패:", error);
-    throw error;
   }
 };
 

--- a/src/api/server/community/mock.server.ts
+++ b/src/api/server/community/mock.server.ts
@@ -24,13 +24,12 @@ export const getCommunities = async( category: string = "none", page: string = "
 export const getCommunity = async (postId: string): Promise<CommunityProps|null> => {
   try {
     const res = buildCommunityDetail(Number(postId));
-    const body = res;
-    console.log("API 응답 데이터:", body);
+    console.log("API 응답 데이터:", res);
 
     return {
-      ...body,
-      commentList: body.commentList ?? [],
-      images: body.images ?? [],
+      ...res,
+      commentList: res.commentList ?? [],
+      images: res.images ?? [],
     };
   } catch (error) {
     console.error("[getCommunity] error::", error);

--- a/src/app/community/_components/CategoryFilter.tsx
+++ b/src/app/community/_components/CategoryFilter.tsx
@@ -16,6 +16,14 @@ import { CATEGORIES } from "@/constants/categories";
 //   { name: "수영대회", key: "competition" },
 // ];
 
+//Mock
+const CATEGORY_LABEL_MAP: Record<string, string> = {
+  COMMUNICATION: "소통해요",
+  POOL: "수영장",
+  GOODS: "수영물품",
+  COMPETITION: "수영대회",
+};
+
 export default function CategoryFilter({
   community,
   selectedCategory,
@@ -23,9 +31,9 @@ export default function CategoryFilter({
   community: CommunitiesProps;
   selectedCategory: string;
 }) {
-  const categoryName =
-    CATEGORIES.find((category) => category.key === selectedCategory)?.name ||
-    "알 수 없음";
+  // const categoryName =
+  //   CATEGORIES.find((category) => category.key === selectedCategory)?.name ||
+  //   "알 수 없음";
 
   // console.warn(":::::::::::::::::::::::카테고리필터의 postID:", community.postId);
 
@@ -42,7 +50,8 @@ export default function CategoryFilter({
             <div
               className={`text-label_sb px-1.5 py-1 mt-4 rounded bg-chip-1 text-chip-1-foreground inline-block w-fit`}
             >
-              <p>{community.categoryName || "\u00A0"}</p>
+              {/* <p>{community.categoryName || "\u00A0"}</p> */}
+              <p>{CATEGORY_LABEL_MAP[community.categoryName ?? ""] ?? ""}</p>
             </div>
 
             {/* {selectedCategory === "none" || selectedCategory === "popular" ? 

--- a/src/app/community/_components/CategoryFilter.tsx
+++ b/src/app/community/_components/CategoryFilter.tsx
@@ -6,6 +6,7 @@ import WriterProfile from "./WriterProfile";
 import { useState } from "react";
 import { CommunitiesProps } from "@/types/community";
 import { CATEGORIES } from "@/constants/categories";
+import { formatKST } from "@/utils";
 
 // const CATEGORIES = [
 //   { name: "전체", key: "none" },
@@ -137,8 +138,7 @@ export default function CategoryFilter({
             } */}
 
             <span className="mt-3 text-b text-gray-500 ml-auto">
-              {community.createdAt.split(" ")[0]}
-              {/* {community.createdAt.slice(0, 11)} */}
+              {formatKST(community.createdAt)}
             </span>
           </div>
         </div>

--- a/src/app/community/_components/CommentList.tsx
+++ b/src/app/community/_components/CommentList.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Comment } from "../comments/Comment";
-import { getComments } from "@/api/server/community/mock";
+import { getComments } from "@/api/server/community/mock.server";
 import { CommentProps } from "@/types/community";
 
 export default function CommentList({

--- a/src/app/community/comments/Comment.tsx
+++ b/src/app/community/comments/Comment.tsx
@@ -4,9 +4,8 @@
 //   return <div>댓글 페이지</div>;
 // }
 
-import { getComments } from "@/api/server/community/mock.server";
-import { getUser } from "@/actions/user";
 import { RiShare2Line } from "react-icons/ri";
+import { formatKST } from "@/utils";
 import WriterProfile from "../_components/WriterProfile";
 import { VscKebabVertical } from "react-icons/vsc";
 import { useEffect, useState } from "react";
@@ -76,7 +75,7 @@ export const Comment = ({
       <p className="text-gray-700 px-4 mt-2">{content}</p>
 
       <div className="flex flex-row items-center gap-2 mt-2">
-        <span className="text-sm text-gray-500 pl-4">{createdAt}</span>
+        <span className="text-sm text-gray-500 pl-4">{formatKST(createdAt)}</span>
         <button type="button" className="text-xs text-gray-600">
           <span>답글 쓰기</span>
         </button>

--- a/src/app/community/comments/Comment.tsx
+++ b/src/app/community/comments/Comment.tsx
@@ -4,7 +4,7 @@
 //   return <div>댓글 페이지</div>;
 // }
 
-import { getComments } from "@/api/server/community/mock";
+import { getComments } from "@/api/server/community/mock.server";
 import { getUser } from "@/actions/user";
 import { RiShare2Line } from "react-icons/ri";
 import WriterProfile from "../_components/WriterProfile";

--- a/src/app/community/posts/[id]/clientPage.tsx
+++ b/src/app/community/posts/[id]/clientPage.tsx
@@ -19,24 +19,33 @@ import {
   deleteLikePost,
   openGraph,
 } from "@/api/server/community/real";
-import { getCommunity } from "@/api/server/community";
+import { getPost } from "@/lib/community/communityRepo.client";
+import { formatKST } from "@/utils";
 import DetailPagePhotoSlider from "@/app/_components/PhotoSlider";
 import CommentList from "../../_components/CommentList";
 
-export default function ClientCommunity({
-  community,
-}: {
-  community: CommunityProps;
-}) {
-  console.warn("::::::::::postId가 넘어오니?::", community.postId);
+export default function ClientCommunity({ postId }: { postId: number }) {
+  const [community, setCommunity] = useState<CommunityProps | null>(null);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [comment, setComment] = useState("");
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [changeLiked, setChangeLiked] = useState(community.isLiked);
-  const [changeLikesCnt, setChangeLikesCnt] = useState(community.likesCnt);
+  const [changeLiked, setChangeLiked] = useState(false);
+  const [changeLikesCnt, setChangeLikesCnt] = useState(0);
   const router = useRouter();
+
+  useEffect(() => {
+    getPost(postId).then((post) => {
+      if (!post) {
+        router.back();
+        return;
+      }
+      setCommunity(post);
+      setChangeLiked(post.isLiked);
+      setChangeLikesCnt(post.likesCnt);
+    });
+  }, [postId]);
   // console.warn("코멘트 안오냐?:::::::::::", community.commentList);
 
   //og관련
@@ -91,8 +100,8 @@ export default function ClientCommunity({
   };
 
   const handleDelete = async () => {
-    const isDeleted = await deleteCommunity(community.postId + "", "1");
-    console.warn("삭제된 게시글:", community.postId);
+    const isDeleted = await deleteCommunity(postId + "", "1");
+    console.warn("삭제된 게시글:", postId);
 
     if (isDeleted) {
       await router.replace("/community/posts/list?category=none&page=0");
@@ -103,6 +112,8 @@ export default function ClientCommunity({
   };
 
   const handleLike = async () => {
+    if(!community) return;
+    
     console.warn("현재 좋아요의 상태는?:::::::::::::::::::", community.isLiked);
 
     try {
@@ -110,8 +121,8 @@ export default function ClientCommunity({
       setChangeLikesCnt((prev) => (changeLiked ? prev - 1 : prev + 1));
 
       const response = changeLiked
-        ? await deleteLikePost(community.postId + "", "1") //좋아요가 되어있으면
-        : await addLikePost(community.postId + "", "1"); //좋아요가 안되어있으면
+        ? await deleteLikePost(postId + "", "1") //좋아요가 되어있으면
+        : await addLikePost(postId + "", "1"); //좋아요가 안되어있으면
 
       if (!response || !response.success || response.data === null) {
         throw new Error(response?.message || "서버 응답 오류");
@@ -134,7 +145,7 @@ export default function ClientCommunity({
   const handleCommentSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const formData = new FormData();
-    formData.append("postId", String(community.postId));
+    formData.append("postId", String(postId));
     formData.append("content", comment);
     formData.append("memberId", "1");
 
@@ -167,23 +178,9 @@ export default function ClientCommunity({
     }
   };
 
-  //최신데이터 가져오기
-  useEffect(() => {
-    const fetchPost = async () => {
-      try {
-        const reloadPost = await getCommunity(community.postId + "");
-
-        if (reloadPost) {
-          setChangeLiked(reloadPost?.isLiked);
-          setChangeLikesCnt(reloadPost?.likesCnt);
-        }
-      } catch (error) {
-        console.error("초기 데이터 동기화 오류:", error);
-      }
-    };
-
-    fetchPost();
-  }, [community.postId]);
+  if (!community) {
+    return <div className="flex justify-center py-20 text-gray-400 text-sm">로딩중...</div>;
+  }
 
   return (
     <div className="flex flex-col pb-10 relative h-full">
@@ -224,7 +221,7 @@ export default function ClientCommunity({
 
           <div className="flex gap-2 text-sm text-gray-500">
             <span className="text-sm text-gray-500 ml-auto">
-              {community.createdAt}
+              {formatKST(community.createdAt)}
             </span>
             <span className="text-sm text-gray-500 ml-auto">
               조회{community.viewCnt}

--- a/src/app/community/posts/[id]/clientPage.tsx
+++ b/src/app/community/posts/[id]/clientPage.tsx
@@ -19,7 +19,7 @@ import {
   deleteLikePost,
   getCommunity,
   openGraph,
-} from "@/api/server/community/mock";
+} from "@/api/server/community/mock.server";
 import DetailPagePhotoSlider from "@/app/_components/PhotoSlider";
 import CommentList from "../../_components/CommentList";
 

--- a/src/app/community/posts/[id]/clientPage.tsx
+++ b/src/app/community/posts/[id]/clientPage.tsx
@@ -17,9 +17,9 @@ import {
   createComment,
   deleteCommunity,
   deleteLikePost,
-  getCommunity,
   openGraph,
-} from "@/api/server/community/mock.server";
+} from "@/api/server/community/real";
+import { getCommunity } from "@/api/server/community";
 import DetailPagePhotoSlider from "@/app/_components/PhotoSlider";
 import CommentList from "../../_components/CommentList";
 
@@ -38,34 +38,31 @@ export default function ClientCommunity({
   const [changeLikesCnt, setChangeLikesCnt] = useState(community.likesCnt);
   const router = useRouter();
   // console.warn("코멘트 안오냐?:::::::::::", community.commentList);
-  
+
   //og관련
   const [preview, setPreview] = useState<any>(null);
   const urlRegex = /(https?:\/\/[^\s]+)/g; //OG추출을 위한 정규표현식
   useEffect(() => {
-    if(!community?.content) return;
+    if (!community?.content) return;
 
     const matchUrls = community.content.match(urlRegex);
     const lastUrl = matchUrls?.[matchUrls?.length - 1]; //마지막링크
-    if(!lastUrl) return;
+    if (!lastUrl) return;
 
     const fetchOG = async () => {
       try {
         const og = await openGraph(lastUrl);
-        if(og) {
+        if (og) {
           setPreview(og);
         }
-
       } catch (error) {
         console.log("OG미리보기 불러오기 실패", error);
       }
-    }
+    };
 
     fetchOG();
+  }, [community?.content]);
 
-  },[community?.content]);
-
-  
   const handleTextareaHeight = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const textarea = textareaRef.current;
 
@@ -165,11 +162,10 @@ export default function ClientCommunity({
       await navigator.clipboard.writeText(window.location.href);
       alert("링크가 복사되었습니다!");
     } catch (error) {
-       alert("링크 복사에 실패하였습니다!");
+      alert("링크 복사에 실패하였습니다!");
       console.error("클립보드 복사 실패!::", error);
     }
   };
-
 
   //최신데이터 가져오기
   useEffect(() => {
@@ -262,22 +258,26 @@ export default function ClientCommunity({
 
         {/* og삽입 */}
         {preview && (
-          <a 
-          href={preview.url}
-          target="_blank"
-          className="block mt-4 p-4 border rounded bg-gray-100 hover:bg-gray-200"
+          <a
+            href={preview.url}
+            target="_blank"
+            className="block mt-4 p-4 border rounded bg-gray-100 hover:bg-gray-200"
           >
             <div className="flex gap-4">
               {preview.image && (
                 <img
-                src={preview.image}
-                alt="미리보기 이미지"
-                className="w-20 h-20 object-cover rounded border"
+                  src={preview.image}
+                  alt="미리보기 이미지"
+                  className="w-20 h-20 object-cover rounded border"
                 />
               )}
               <div className="overflow-hidden">
-                <p className="font-bold text-sm line-clamp-2">{preview.title}</p>
-                <p className="text-xs text-gray-600 mt-1 line-clamp-1">{preview.description}</p>
+                <p className="font-bold text-sm line-clamp-2">
+                  {preview.title}
+                </p>
+                <p className="text-xs text-gray-600 mt-1 line-clamp-1">
+                  {preview.description}
+                </p>
               </div>
             </div>
           </a>
@@ -297,7 +297,10 @@ export default function ClientCommunity({
           <span className="text-gray-700">{changeLikesCnt}</span>
         </button>
         <button className="flex justify-center items-center gap-1 flex-1">
-          <RiShare2Line className="w-5 h-5 text-gray-700" onClick={handleCopyLink}/>
+          <RiShare2Line
+            className="w-5 h-5 text-gray-700"
+            onClick={handleCopyLink}
+          />
           <p className="text-gray-500"></p>
         </button>
       </div>

--- a/src/app/community/posts/[id]/edit/page.tsx
+++ b/src/app/community/posts/[id]/edit/page.tsx
@@ -8,7 +8,6 @@ import { AiOutlineLink } from "react-icons/ai";
 import { IoIosArrowDown } from "react-icons/io";
 import { useEffect, useRef, useState } from "react";
 import {
-  createCommunity,
   getCommunity,
   openGraph,
   updateCommunity,

--- a/src/app/community/posts/[id]/edit/page.tsx
+++ b/src/app/community/posts/[id]/edit/page.tsx
@@ -12,7 +12,7 @@ import {
   getCommunity,
   openGraph,
   updateCommunity,
-} from "@/api/server/community/mock";
+} from "@/api/server/community/mock.server";
 import { useRouter } from "next/navigation";
 import OpenGraphPreview from "@/app/_components/OpenGraphLinkReview";
 

--- a/src/app/community/posts/[id]/page.tsx
+++ b/src/app/community/posts/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { getCommunity } from "@/api/server/community/mock";
+import { getCommunity } from "@/api/server/community/mock.server";
 import { notFound } from "next/navigation";
 import ClientCommunityPage from "./clientPage";
 

--- a/src/app/community/posts/[id]/page.tsx
+++ b/src/app/community/posts/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { getCommunity } from "@/api/server/community/mock.server";
+import { getCommunity } from "@/api/server/community";
 import { notFound } from "next/navigation";
 import ClientCommunityPage from "./clientPage";
 

--- a/src/app/community/posts/[id]/page.tsx
+++ b/src/app/community/posts/[id]/page.tsx
@@ -1,18 +1,7 @@
-import { getCommunity } from "@/api/server/community";
-import { notFound } from "next/navigation";
 import ClientCommunityPage from "./clientPage";
 
-const CommunityPage = async ({ params }: { params: { id: string } }) => {
-  const CommunityId = params.id;
-  console.warn("CommunityId:::::::::::::::::::::",CommunityId);
-  const community = await getCommunity(CommunityId);
-  console.warn("Community코멘트 들고왔나?:::::::::::::::::::::", community?.commentList);
-
-  if (!community) {
-    notFound();
-  }
-
-  return (<ClientCommunityPage community={community} />);
+const CommunityPage = ({ params }: { params: { id: string } }) => {
+  return <ClientCommunityPage postId={Number(params.id)} />;
 };
 
 export default CommunityPage;

--- a/src/app/community/posts/list/clientPage.tsx
+++ b/src/app/community/posts/list/clientPage.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import FloatingButton from "../../_components/FloatingButton";
 import CategoryFilter from "@/app/community/_components/CategoryFilter";
-import { getCommunities } from "@/api/server/community/mock.server";
+import { getCommunities } from "@/api/server/community";
 import { useRouter } from "next/navigation";
 import {
   CommunitiesProps,
@@ -79,21 +79,30 @@ export default function CommunitiesClient({
 
   //Mock
   useEffect(() => {
-  ensureSeeded();
+  let cancelled = true;
+  const makeMockList = async () => {
 
-  const posts = listPosts();
-  let filtered = posts;
-  if(category === "popular") {
-    filtered = posts.filter(p => p.isPopular);
-  }else{
-    const categoryValue = KEY_TO_CATEGORYNAME[category];
-    if(categoryValue) filtered = posts.filter(p => p.categoryName === categoryValue);
-  }
+    await ensureSeeded();
+    
+    const posts = await listPosts();
+    let filtered = posts;
 
-  // const listItems = posts.map(toListItem);
-  setCommunities(filtered.map(toListItem));
-  setHasMore(false);
-  setCurrentPage(0);
+    if(category === "popular") {
+      filtered = posts.filter(p => p.isPopular);
+    }else{
+      const categoryValue = KEY_TO_CATEGORYNAME[category];
+      if(categoryValue) filtered = posts.filter(p => p.categoryName === categoryValue);
+    }
+
+    if(!cancelled) return;
+    // const listItems = posts.map(toListItem);
+    setCommunities(filtered.map(toListItem));
+    setHasMore(false);
+    setCurrentPage(0);
+  };
+  makeMockList();
+
+  return () => { cancelled = false; }
 }, [category]);
 
   //무한스크롤

--- a/src/app/community/posts/list/clientPage.tsx
+++ b/src/app/community/posts/list/clientPage.tsx
@@ -1,199 +1,114 @@
 "use client";
 
-import Link from "next/link";
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useInView } from "react-intersection-observer";
 import FloatingButton from "../../_components/FloatingButton";
 import CategoryFilter from "@/app/community/_components/CategoryFilter";
-import { getCommunities } from "@/api/server/community";
-import { useRouter } from "next/navigation";
-import {
-  CommunitiesProps,
-  communityResponseDetailProps,
-  communityResponseProps,
-} from "@/types/community";
 import { CATEGORIES, KEY_TO_CATEGORYNAME } from "@/constants/categories";
-import { useInView } from "react-intersection-observer";
-import { ensureSeeded, listPosts, toListItem } from "@/lib/community/communityRepo.client";
+import { listPage } from "@/lib/community/communityRepo.client";
+import { CommunitiesProps } from "@/types/community";
 
-// export const CATEGORIES = [
-//   {name: "전체", key: "none"},
-//   {name: "인기글", key: "popular"},
-//   {name: "소통해요", key: "communication"},
-//   {name: "수영장", key: "pool"},
-//   {name: "수영물품", key: "goods"},
-//   {name: "수영대회", key: "competition"},
-// ];
+const PAGE_SIZE = 10;
+type CategoryKey = keyof typeof KEY_TO_CATEGORYNAME;
 
 export default function CommunitiesClient({
-  communityList,
   category,
-  page,
 }: {
-  // communityList: CommunitiesProps[];
-  communityList: communityResponseDetailProps;
   category: string;
-  page: string;
-  // hasMore: boolean;
-  // totalposts: number;
 }) {
-  // const [selectedCategory, setSelectedCategory] = useState<string>(category); //기본 카테고리
-  const [communities, setCommunities] = useState<CommunitiesProps[]>(
-    communityList.posts,
-  ); //초기 데이터
-
-  //무한스크롤 추가
-  const [currentPage, setCurrentPage] = useState<number>(Number(page) || 0);
-  const [hasMore, setHasMore] = useState<boolean>(communityList.hasMore);
-  const { ref, inView } = useInView({
-    threshold: 0.5, // 요소가 50% 보일 때 inView가 true로 바뀜
-  });
-
+  const categoryKey = category as CategoryKey;
+  const [items, setItems] = useState<CommunitiesProps[]>([]);
+  const [page, setPage] = useState(0);
+  const [hasNext, setHasNext] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const { ref, inView } = useInView({ threshold: 0 });
   const router = useRouter();
 
-  //카테고리 변경시 URL 업데이트
-  // useEffect(() => {
-  //   //카테고리 변경시 데이터 가져옴
-  //   let isCancel = false;
-  //   const fetchData = async () => {
-  //     try {
-  //       // const page = "0";
-  //       // router.replace(`/community/posts/list?category=${category}&page=${page}`);
-  //       const data = await getCommunities(category, page);
-  //       if (isCancel) return;
-
-  //       setCommunities(data.posts);
-  //       setHasMore(data.hasMore);
-  //       setCurrentPage(Number(page) || 0);
-  //     } catch (error) {
-  //       console.error("[communityList error]::", error);
-  //       setHasMore(false);
-  //     }
-  //   };
-
-  //   fetchData();
-  //   return () => {
-  //     isCancel = true;
-  //   };
-  // }, [category, page]);
-
-
-  //Mock
+  // Reset state when category changes
   useEffect(() => {
-  let cancelled = true;
-  const makeMockList = async () => {
+    setItems([]);
+    setPage(0);
+    setHasNext(true);
+  }, [categoryKey]);
 
-    await ensureSeeded();
-    
-    const posts = await listPosts();
-    let filtered = posts;
+  // Load a page whenever categoryKey or page changes
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
 
-    if(category === "popular") {
-      filtered = posts.filter(p => p.isPopular);
-    }else{
-      const categoryValue = KEY_TO_CATEGORYNAME[category];
-      if(categoryValue) filtered = posts.filter(p => p.categoryName === categoryValue);
+    listPage({ categoryKey, page, pageSize: PAGE_SIZE })
+      .then((result) => {
+        if (cancelled) return;
+        setItems((prev) => (page === 0 ? result.items : [...prev, ...result.items]));
+        setHasNext(result.hasNext);
+      })
+      .catch(() => {
+        if (!cancelled) setHasNext(false);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [categoryKey, page]);
+
+  // Trigger next page when sentinel enters view
+  useEffect(() => {
+    if (inView && hasNext && !loading) {
+      setPage((p) => p + 1);
     }
-
-    if(!cancelled) return;
-    // const listItems = posts.map(toListItem);
-    setCommunities(filtered.map(toListItem));
-    setHasMore(false);
-    setCurrentPage(0);
-  };
-  makeMockList();
-
-  return () => { cancelled = false; }
-}, [category]);
-
-  //무한스크롤
-  // useEffect(() => {
-  //   if (inView && hasMore) {
-  //     let isCancel = false;
-
-  //     const fetchMoreData = async () => {
-  //       try {
-  //         const nextPage = currentPage + 1;
-  //         const data = await getCommunities(category, String(nextPage));
-  //         if (isCancel) return;
-
-  //         if (data.posts.length > 0) {
-  //           setCommunities((prev) => [...prev, ...data.posts]);
-  //           setHasMore(data.hasMore);
-  //           setCurrentPage(nextPage);
-  //         } else {
-  //           setHasMore(false);
-  //         }
-  //       } catch (error) {
-  //         if (isCancel) return;
-  //         console.error("[communityList error]::", error);
-  //         setHasMore(false);
-  //       }
-  //     };
-
-  //     fetchMoreData();
-  //     return () => {
-  //       isCancel = true;
-  //     };
-  //   }
-  // }, [inView, hasMore, currentPage, category]);
+  }, [inView, hasNext, loading]);
 
   return (
     <div>
-      {/* <div className="flex gap-2 mb-4 px-4"> */}
       <div className="mb-4 px-4 grid grid-cols-3 gap-2 md:flex md:flex-nowrap md:gap-2">
         {CATEGORIES.map((c) => (
           <button
             key={c.key}
             onClick={() =>
-              router.replace(`/community/posts/list?category=${c.key}&page=0`)
+              router.replace(`/community/posts/list?category=${c.key}`)
             }
             className={`w-full md:w-auto px-2 py-1 text-xs md:px-4 md:py-2 md:text-base
-                        rounded-full whitespace-nowrap 
-           ${
-             category === c.key
-               ? "bg-gray-300 text-black font-bold"
-               : "bg-gray-100 text-gray-500 font-bold"
-           } 
-              hover:bg-gray-300`}
+                        rounded-full whitespace-nowrap font-bold
+                        ${category === c.key ? "bg-gray-300 text-black" : "bg-gray-100 text-gray-500"}
+                        hover:bg-gray-300`}
           >
             {c.name}
           </button>
         ))}
       </div>
 
-      {/*로딩 중*/}
-      {/* {loading? (
-          <p>로딩 중...</p>
-        ) : ( */}
       <ul className="flex flex-col gap-1 px-4 pb-10">
-        {communities && communities.length > 0 ? (
-          communities.map((community) => (
+        {items.length > 0 ? (
+          items.map((community) => (
             <CategoryFilter
               key={community.postId}
               community={community}
               selectedCategory={category}
             />
           ))
-        ) : (
-          // <p className="text-gray-500">해당 커뮤니티가 존재하지 않습니다.</p>
+        ) : !loading ? (
           <p className="text-gray-500"></p>
-        )}
+        ) : null}
       </ul>
-      {/* )} */}
+
       <FloatingButton />
-      {/* 무한스크롤 감지 */}
-      {hasMore ? (
-        <div className="flex justify-center pb-8 gap-2">
-          <div className="w-6 h-6 border-4 border-gray-300 border-t-gray-500 rounded-full animate-spin"></div>
-          <div ref={ref} className="text-gray-400">
-            Loading more...
+
+      {/* Infinite scroll sentinel — always rendered so the observer stays active */}
+      <div ref={ref} className="py-4 flex justify-center">
+        {loading && (
+          <div className="flex items-center gap-2">
+            <div className="w-6 h-6 border-4 border-gray-300 border-t-gray-500 rounded-full animate-spin" />
+            <span className="text-gray-400">Loading more...</span>
           </div>
-        </div>
-      ) : (
-        <p className="text-center text-gray-400 pb-8">
-          더 이상 게시물이 없습니다.
-        </p>
-      )}
+        )}
+        {!hasNext && !loading && (
+          <p className="pb-8 text-center text-gray-400">더 이상 게시물이 없습니다.</p>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/app/community/posts/list/clientPage.tsx
+++ b/src/app/community/posts/list/clientPage.tsx
@@ -4,15 +4,16 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import FloatingButton from "../../_components/FloatingButton";
 import CategoryFilter from "@/app/community/_components/CategoryFilter";
-import { getCommunities } from "@/api/server/community/mock";
+import { getCommunities } from "@/api/server/community/mock.server";
 import { useRouter } from "next/navigation";
 import {
   CommunitiesProps,
   communityResponseDetailProps,
   communityResponseProps,
 } from "@/types/community";
-import { CATEGORIES } from "@/constants/categories";
+import { CATEGORIES, KEY_TO_CATEGORYNAME } from "@/constants/categories";
 import { useInView } from "react-intersection-observer";
+import { ensureSeeded, listPosts, toListItem } from "@/lib/community/communityRepo.client";
 
 // export const CATEGORIES = [
 //   {name: "전체", key: "none"},
@@ -50,62 +51,82 @@ export default function CommunitiesClient({
   const router = useRouter();
 
   //카테고리 변경시 URL 업데이트
+  // useEffect(() => {
+  //   //카테고리 변경시 데이터 가져옴
+  //   let isCancel = false;
+  //   const fetchData = async () => {
+  //     try {
+  //       // const page = "0";
+  //       // router.replace(`/community/posts/list?category=${category}&page=${page}`);
+  //       const data = await getCommunities(category, page);
+  //       if (isCancel) return;
+
+  //       setCommunities(data.posts);
+  //       setHasMore(data.hasMore);
+  //       setCurrentPage(Number(page) || 0);
+  //     } catch (error) {
+  //       console.error("[communityList error]::", error);
+  //       setHasMore(false);
+  //     }
+  //   };
+
+  //   fetchData();
+  //   return () => {
+  //     isCancel = true;
+  //   };
+  // }, [category, page]);
+
+
+  //Mock
   useEffect(() => {
-    //카테고리 변경시 데이터 가져옴
-    let isCancel = false;
-    const fetchData = async () => {
-      try {
-        // const page = "0";
-        // router.replace(`/community/posts/list?category=${category}&page=${page}`);
-        const data = await getCommunities(category, page);
-        if (isCancel) return;
+  ensureSeeded();
 
-        setCommunities(data.posts);
-        setHasMore(data.hasMore);
-        setCurrentPage(Number(page) || 0);
-      } catch (error) {
-        console.error("[communityList error]::", error);
-        setHasMore(false);
-      }
-    };
+  const posts = listPosts();
+  let filtered = posts;
+  if(category === "popular") {
+    filtered = posts.filter(p => p.isPopular);
+  }else{
+    const categoryValue = KEY_TO_CATEGORYNAME[category];
+    if(categoryValue) filtered = posts.filter(p => p.categoryName === categoryValue);
+  }
 
-    fetchData();
-    return () => {
-      isCancel = true;
-    };
-  }, [category, page]);
+  // const listItems = posts.map(toListItem);
+  setCommunities(filtered.map(toListItem));
+  setHasMore(false);
+  setCurrentPage(0);
+}, [category]);
 
   //무한스크롤
-  useEffect(() => {
-    if (inView && hasMore) {
-      let isCancel = false;
+  // useEffect(() => {
+  //   if (inView && hasMore) {
+  //     let isCancel = false;
 
-      const fetchMoreData = async () => {
-        try {
-          const nextPage = currentPage + 1;
-          const data = await getCommunities(category, String(nextPage));
-          if (isCancel) return;
+  //     const fetchMoreData = async () => {
+  //       try {
+  //         const nextPage = currentPage + 1;
+  //         const data = await getCommunities(category, String(nextPage));
+  //         if (isCancel) return;
 
-          if (data.posts.length > 0) {
-            setCommunities((prev) => [...prev, ...data.posts]);
-            setHasMore(data.hasMore);
-            setCurrentPage(nextPage);
-          } else {
-            setHasMore(false);
-          }
-        } catch (error) {
-          if (isCancel) return;
-          console.error("[communityList error]::", error);
-          setHasMore(false);
-        }
-      };
+  //         if (data.posts.length > 0) {
+  //           setCommunities((prev) => [...prev, ...data.posts]);
+  //           setHasMore(data.hasMore);
+  //           setCurrentPage(nextPage);
+  //         } else {
+  //           setHasMore(false);
+  //         }
+  //       } catch (error) {
+  //         if (isCancel) return;
+  //         console.error("[communityList error]::", error);
+  //         setHasMore(false);
+  //       }
+  //     };
 
-      fetchMoreData();
-      return () => {
-        isCancel = true;
-      };
-    }
-  }, [inView, hasMore, currentPage, category]);
+  //     fetchMoreData();
+  //     return () => {
+  //       isCancel = true;
+  //     };
+  //   }
+  // }, [inView, hasMore, currentPage, category]);
 
   return (
     <div>

--- a/src/app/community/posts/list/page.tsx
+++ b/src/app/community/posts/list/page.tsx
@@ -1,4 +1,4 @@
-import { getCommunities } from "@/api/server/community/mock";
+import { getCommunities } from "@/api/server/community/mock.server";
 import Link from "next/link";
 import Image from "next/image";
 import CommunitiesClient from "./clientPage";

--- a/src/app/community/posts/list/page.tsx
+++ b/src/app/community/posts/list/page.tsx
@@ -1,17 +1,16 @@
-import { getCommunities } from "@/api/server/community/mock.server";
-import Link from "next/link";
 import Image from "next/image";
 import CommunitiesClient from "./clientPage";
 import { CATEGORIES } from "@/constants/categories";
 
-export default async function CommunityPage({searchParams}: {searchParams: {category?: string; page?: string};}) {
+export default async function CommunityPage({
+  searchParams,
+}: {
+  searchParams: { category?: string };
+}) {
   const category = searchParams.category || "none";
-  const page = searchParams.page || "0";
-  console.log("category:", category, "page:", page); 
+  const selectedCategoryName =
+    CATEGORIES.find((cate) => cate.key === category)?.name || "전체";
 
-  const communities = await getCommunities(category, page);
-  const selectedCategoryName = CATEGORIES.find((cate) => cate.key === category)?.name || "전체";
-  
   return (
     <div className="flex flex-col">
       <header className="flex gap-2 pt-4 px-4">
@@ -29,11 +28,10 @@ export default async function CommunityPage({searchParams}: {searchParams: {cate
       <section className="flex flex-col">
         <div className="flex items-center gap-2 pt-6 px-4 pb-5">
           <h2 className="text-heading_2">{selectedCategoryName}</h2>
-          {/* <p className="text-body_lb text-gray-500">{communities.posts.length}</p> */}
         </div>
 
         <div>
-          <CommunitiesClient communityList={communities} category={category} page={page}/>
+          <CommunitiesClient category={category} />
         </div>
       </section>
     </div>

--- a/src/app/community/posts/page.tsx
+++ b/src/app/community/posts/page.tsx
@@ -7,9 +7,10 @@ import { MdOutlineBrokenImage } from "react-icons/md";
 import { AiOutlineLink } from "react-icons/ai";
 import { IoIosArrowDown } from "react-icons/io";
 import { useEffect, useRef, useState } from "react";
-import { createCommunity, openGraph } from "@/api/server/community/mock";
+import { openGraph } from "@/api/server/community/mock.server";
 import { useRouter } from "next/navigation";
 import OpenGraphPreview from "@/app/_components/OpenGraphLinkReview";
+import { createCommunity } from "@/api/server/community/mock.client";
 
 // const CATEGORIES = ["소통해요", "수영장", "수영물품", "수영대회"];
 const CATEGORIES = [
@@ -75,6 +76,7 @@ export default function CreatePost() {
 
     formData.append("content", content);
 
+    //임시
     const userId = "1";
     formData.append("memberId", userId); //마이페이지 보고 가져오기
 

--- a/src/app/community/posts/page.tsx
+++ b/src/app/community/posts/page.tsx
@@ -7,10 +7,10 @@ import { MdOutlineBrokenImage } from "react-icons/md";
 import { AiOutlineLink } from "react-icons/ai";
 import { IoIosArrowDown } from "react-icons/io";
 import { useEffect, useRef, useState } from "react";
-import { openGraph } from "@/api/server/community/mock.server";
+import { openGraph } from "@/api/server/community/mock.server"; //추후 수정하기!!
 import { useRouter } from "next/navigation";
 import OpenGraphPreview from "@/app/_components/OpenGraphLinkReview";
-import { createCommunity } from "@/api/server/community/mock.client";
+import { createCommunity } from "@/api/server/community";
 
 // const CATEGORIES = ["소통해요", "수영장", "수영물품", "수영대회"];
 const CATEGORIES = [

--- a/src/constants/categories.ts
+++ b/src/constants/categories.ts
@@ -6,3 +6,26 @@ export const CATEGORIES = [
   { name: "수영물품", key: "goods" },
   { name: "수영대회", key: "competition" },
 ];
+
+//Mock-url change
+export const KEY_TO_CATEGORYNAME = {
+  none: null,
+  popular: null,
+  communication: "COMMUNICATION",
+  pool: "POOL",
+  goods: "GOODS",
+  competition: "COMPETITION",
+} as const;
+
+// export type CategoryName = "COMMUNICATION" | "POOL" | "GOODS" | "COMPETITION"; 
+export const CATEGORY_NAMES = ["COMMUNICATION", "POOL", "GOODS", "COMPETITION"] as const;
+export type CategoryName = (typeof CATEGORY_NAMES)[number];
+
+export function toCategoryName(input: string): CategoryName {
+  const upper = input.toUpperCase();
+  if((CATEGORY_NAMES as readonly string[]).includes(upper)){
+    return upper as CategoryName;
+  }
+  console.warn("Unknown category from server::", input);
+  return "COMMUNICATION";
+}

--- a/src/lib/community/communityRepo.client.ts
+++ b/src/lib/community/communityRepo.client.ts
@@ -1,9 +1,10 @@
 "use client";
 
 import { CommunitiesProps, CommunityProps } from "@/types/community";
-import { buildCommunityList } from "./mockCommunityList";
 import { buildCommunityDetail } from "./mockCommunityDetail";
-import { CATEGORY_NAMES, CategoryName } from "@/constants/categories";
+import { CATEGORY_NAMES, CategoryName, KEY_TO_CATEGORYNAME } from "@/constants/categories";
+
+type CategoryKey = keyof typeof KEY_TO_CATEGORYNAME;
 
 const STORAGE_KEY = "mock_communities_v1";
 const SEEDED_KEY = "mock_communities_seeded_v1";
@@ -50,20 +51,15 @@ export async function ensureSeeded(category: string = "none") {
     return;
   }
 
-  //seed데이터 생성
-  // const seedListRes = buildCommunityList(category, 0);
-  const seedListRes = buildCommunityList(category, 0);
-  const seedPosts: CommunitiesProps[] = seedListRes.data.posts;
-
-  //detail로 확장
-  const fullPosts: CommunityProps[] = seedPosts.map((p) => {
-    const detail = buildCommunityDetail(Number(p.postId));
+  // seed 데이터 35개 직접 생성
+  const SEED_COUNT = 35;
+  const fullPosts: CommunityProps[] = Array.from({ length: SEED_COUNT }, (_, i) => {
+    const postId = i + 1;
+    const detail = buildCommunityDetail(postId);
     const categoryName = randomCategory();
-    // const categoryName = detail.categoryName ?? p.categoryName ?? randomCategory();
-
     const likesCnt = randomInt(0, 120);
     const viewCnt = randomInt(0, 1500);
-    const isPopular = likesCnt >= 50;
+    const isPopular = likesCnt >= 80;
 
     return {
       ...detail,
@@ -112,6 +108,46 @@ export async function createPost(newPost: CommunityProps): Promise<number> {
     // 선택 2) throw 해서 UI에서 토스트 띄우기
     throw error;
   }
-  
+
   return newPost.postId;
+}
+
+export async function listPage(params: {
+  categoryKey: CategoryKey;
+  page: number;
+  pageSize: number;
+}): Promise<{
+  items: CommunitiesProps[];
+  page: number;
+  pageSize: number;
+  total: number;
+  hasNext: boolean;
+}> {
+  await ensureSeeded();
+  const { categoryKey, page, pageSize } = params;
+
+  const posts = await listPosts();
+
+  let filtered: CommunityProps[];
+  if (categoryKey === "popular") {
+    filtered = posts.filter((p) => p.isPopular);
+  } else {
+    const categoryValue = KEY_TO_CATEGORYNAME[categoryKey];
+    filtered = categoryValue ? posts.filter((p) => p.categoryName === categoryValue) : posts;
+  }
+
+  const sorted = [...filtered].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+
+  const total = sorted.length;
+  const start = page * pageSize;
+
+  return {
+    items: sorted.slice(start, start + pageSize).map(toListItem),
+    page,
+    pageSize,
+    total,
+    hasNext: start + pageSize < total,
+  };
 }

--- a/src/lib/community/communityRepo.client.ts
+++ b/src/lib/community/communityRepo.client.ts
@@ -1,0 +1,117 @@
+"use client";
+
+import { CommunitiesProps, CommunityProps } from "@/types/community";
+import { buildCommunityList } from "./mockCommunityList";
+import { buildCommunityDetail } from "./mockCommunityDetail";
+import { CATEGORY_NAMES, CategoryName } from "@/constants/categories";
+
+const STORAGE_KEY = "mock_communities_v1";
+const SEEDED_KEY = "mock_communities_seeded_v1";
+
+function randomCategory(): CategoryName {
+  return CATEGORY_NAMES[Math.floor(Math.random() * CATEGORY_NAMES.length)];
+}
+
+function randomInt(min: number, max: number) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+// function randomPopular(likesCnt: number) {
+//   return likesCnt >= 30;
+// }
+
+//community -> communities로 변환
+export function toListItem(post: CommunityProps): CommunitiesProps {
+  return {
+    postId: post.postId,
+    categoryName: post.categoryName,
+    title: post.title,
+    content: post.content,
+    image: post.images?.[0]
+      ? { repImage: post.images[0].repImage, imageUrl: post.images[0].imageUrl }
+      : null,
+    likesCnt: post.likesCnt,
+    cmntCnt: post.cmntCnt,
+    viewCnt: post.viewCnt,
+    writer: post.writer,
+    writerProfile: post.writerProfile,
+    createdAt: post.createdAt,
+    updatedAt: post.updatedAt,
+    isPopular: post.isPopular,
+  };
+}
+
+export async function ensureSeeded(category: string = "none") {
+  if (typeof window === "undefined") return;
+
+  const seeded = localStorage.getItem(SEEDED_KEY);
+  if (seeded === "true") {
+    console.log("seeded::", true);
+    return;
+  }
+
+  //seed데이터 생성
+  // const seedListRes = buildCommunityList(category, 0);
+  const seedListRes = buildCommunityList(category, 0);
+  const seedPosts: CommunitiesProps[] = seedListRes.data.posts;
+
+  //detail로 확장
+  const fullPosts: CommunityProps[] = seedPosts.map((p) => {
+    const detail = buildCommunityDetail(Number(p.postId));
+    const categoryName = randomCategory();
+    // const categoryName = detail.categoryName ?? p.categoryName ?? randomCategory();
+
+    const likesCnt = randomInt(0, 120);
+    const viewCnt = randomInt(0, 1500);
+    const isPopular = likesCnt >= 50;
+
+    return {
+      ...detail,
+      categoryName,
+      likesCnt,
+      viewCnt,
+      isPopular,
+      commentList: detail.commentList ?? [],
+      images: detail.images ?? [],
+    };
+  });
+
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(fullPosts));
+  localStorage.setItem(SEEDED_KEY, "true");
+}
+
+export async function listPosts(): Promise<CommunityProps[]> {
+  try {
+    if (typeof window === "undefined") return [];
+
+    const data = localStorage.getItem(STORAGE_KEY);
+    if(!data) return [];
+
+    return JSON.parse(data);
+
+  } catch (error) {
+    console.error("[listPosts] JSON.parse failed::", error);
+    return [];
+  }
+}
+
+export async function getPost(postId: number): Promise<CommunityProps | null> {
+  const posts = await listPosts();
+  return posts.find((p) => Number(p.postId) === Number(postId)) ?? null;
+}
+
+export async function createPost(newPost: CommunityProps): Promise<number> {
+    try {
+    const posts = await listPosts();
+    posts.unshift(newPost);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(posts));
+
+  } catch (error) {
+    console.error("[createPost] localStorage.setItem failed::", error);
+    // 선택 1) 조용히 무시 (데모니까)
+    // 선택 2) throw 해서 UI에서 토스트 띄우기
+    throw error;
+  }
+  
+  return newPost.postId;
+}

--- a/src/lib/community/mockCommunityDetail.ts
+++ b/src/lib/community/mockCommunityDetail.ts
@@ -3,7 +3,7 @@ import { communityDetailSchema } from "@/schemas/communities";
 export function buildCommunityDetail(postId: number) {
   const post = {
     postId: postId,
-    categoryName: "none",
+    // categoryName: String(category),
     title: `Mock title ${postId}`,
     content: `Mock content ${postId}`,
     images: [  

--- a/src/lib/community/mockCommunityDetail.ts
+++ b/src/lib/community/mockCommunityDetail.ts
@@ -14,7 +14,7 @@ export function buildCommunityDetail(postId: number) {
     cmntCnt: 0,
     writer: "Mock Writer",
     writerProfile: null,
-    createdAt: "2026-01-01 00:00:00",
+    createdAt: "2026-01-01T00:00:00.000Z",
     updatedAt: null,
     commentList: [
       {
@@ -26,7 +26,7 @@ export function buildCommunityDetail(postId: number) {
         writer: "Mock commenter",
         writerProfile: "https://picsum.photos/seed/commenter/100/100",
         likeCnt: 0,
-        createdAt: "2026-01-01 00:00:00",
+        createdAt: "2026-01-01T00:00:00.000Z",
       },
     ],
     isLiked: false,

--- a/src/lib/community/mockCommunityDetail.ts
+++ b/src/lib/community/mockCommunityDetail.ts
@@ -3,7 +3,7 @@ import { communityDetailSchema } from "@/schemas/communities";
 export function buildCommunityDetail(postId: number) {
   const post = {
     postId: postId,
-    // categoryName: String(category),
+    categoryName: "COMMUNICATION", // placeholder — ensureSeeded에서 randomCategory()로 덮어씌움
     title: `Mock title ${postId}`,
     content: `Mock content ${postId}`,
     images: [  

--- a/src/lib/community/mockCommunityList.ts
+++ b/src/lib/community/mockCommunityList.ts
@@ -18,7 +18,7 @@ export function buildCommunityList(category: string, page: number) {
       viewCnt: 0,
       writer: "Mock Writer",
       writerProfile: null,
-      createdAt: "2026-01-01 00:00:00",
+      createdAt: "2026-01-01T00:00:00.000Z",
       updatedAt: null,
       isPopular: false,
     };

--- a/src/lib/community/mockCommunityList.ts
+++ b/src/lib/community/mockCommunityList.ts
@@ -1,5 +1,6 @@
 import { communityResponseSchema } from "@/schemas/communities";
 
+// export function buildCommunityList(category: string, page: number) {
 export function buildCommunityList(category: string, page: number) {
   const pageSize = 10;
   const totalPosts = 35;

--- a/src/schemas/communities.ts
+++ b/src/schemas/communities.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { toCategoryName } from "@/constants/categories";
 
 export const imageSchema = z.object({
   repImage: z.boolean(),
@@ -7,7 +8,7 @@ export const imageSchema = z.object({
 
 export const communitySchema = z.object({
   postId: z.number(),
-  categoryName: z.string(),
+  categoryName: z.string().transform(toCategoryName),
   title: z.string(),
   content: z.string(),
   image: imageSchema.nullable(),
@@ -54,7 +55,7 @@ export const communityDetailReCommentSchema = z.object({
 
 export const communityDetailSchema = z.object({
   postId: z.number(),
-  categoryName: z.string(),
+  categoryName: z.string().transform(toCategoryName),
   title: z.string(),
   content: z.string(),
   images: z.array(imageSchema).max(5).default([]), //이미지가 최대 5장 들어감

--- a/src/schemas/communities.ts
+++ b/src/schemas/communities.ts
@@ -7,7 +7,7 @@ export const imageSchema = z.object({
 
 export const communitySchema = z.object({
   postId: z.number(),
-  categoryName: z.string().optional(),
+  categoryName: z.string(),
   title: z.string(),
   content: z.string(),
   image: imageSchema.nullable(),
@@ -22,6 +22,8 @@ export const communitySchema = z.object({
   updatedAt: z.string().nullable(),
   isPopular: z.boolean(),
 });
+
+export type CommunityApiProps = z.infer<typeof communitySchema>;
 
 // export const postsSchema = z.object({
 //   success: z.boolean(),
@@ -52,7 +54,7 @@ export const communityDetailReCommentSchema = z.object({
 
 export const communityDetailSchema = z.object({
   postId: z.number(),
-  categoryName: z.string().optional(),
+  categoryName: z.string(),
   title: z.string(),
   content: z.string(),
   images: z.array(imageSchema).max(5).default([]), //이미지가 최대 5장 들어감
@@ -70,6 +72,8 @@ export const communityDetailSchema = z.object({
   isPopular: z.boolean(),
   // isPopular: z.string().nullable(),
 });
+
+export type CommunityDetailApiProps = z.infer<typeof communityDetailSchema>;
 
 //페이징을 위한 추가
 export const communityResponseSchema = z.object({

--- a/src/types/community.ts
+++ b/src/types/community.ts
@@ -1,41 +1,50 @@
-import { openGraphSchema } from "@/schemas/communities";
+import { CategoryName } from "@/constants/categories";
+import { CommunityApiProps, CommunityDetailApiProps, openGraphSchema } from "@/schemas/communities";
 import { z } from "zod";
 
-export type CommunitiesProps = {
-  postId: number;
-  categoryName?: string;
-  title: string;
-  content: string;
-  image: { repImage: boolean; imageUrl: string } | null;
-  likesCnt: number;
-  cmntCnt: number;
-  viewCnt: number;
-  writer: string;
-  writerProfile: string | null;
-  createdAt: string;
-  updatedAt: string | null;
-  isPopular: boolean;
+// export type CommunitiesProps = {
+//   postId: number;
+//   categoryName: CategoryName;
+//   title: string;
+//   content: string;
+//   image: { repImage: boolean; imageUrl: string } | null;
+//   likesCnt: number;
+//   cmntCnt: number;
+//   viewCnt: number;
+//   writer: string;
+//   writerProfile: string | null;
+//   createdAt: string;
+//   updatedAt: string | null;
+//   isPopular: boolean;
+// };
+
+export type CommunitiesProps = Omit<CommunityApiProps, "categoryName"> & {
+  categoryName: CategoryName;
 };
 
-export type CommunityProps = {
-  postId: number;
-  categoryName?: string;
-  title: string;
-  content: string;
-  images: { repImage: boolean; imageUrl: string }[];
-  likesCnt: number;
-  viewCnt: number;
-  cmntCnt: number;
-  // cmntCnt: string;
-  writer: string;
-  writerProfile: string | null;
-  createdAt: string;
-  updatedAt: string | null;
-  commentList: CommentProps[];
-  // commentList: [];
-  isLiked: boolean;
-  isPopular: boolean;
+export type CommunityProps = Omit<CommunityDetailApiProps, "categoryName"> & {
+  categoryName: CategoryName;
 };
+
+// export type CommunityProps = {
+//   postId: number;
+//   categoryName: CategoryName;
+//   title: string;
+//   content: string;
+//   images: { repImage: boolean; imageUrl: string }[];
+//   likesCnt: number;
+//   viewCnt: number;
+//   cmntCnt: number;
+//   // cmntCnt: string;
+//   writer: string;
+//   writerProfile: string | null;
+//   createdAt: string;
+//   updatedAt: string | null;
+//   commentList: CommentProps[];
+//   // commentList: [];
+//   isLiked: boolean;
+//   isPopular: boolean;
+// };
 
 export type CommentProps = {
   postId?: number;

--- a/src/types/community.ts
+++ b/src/types/community.ts
@@ -84,7 +84,7 @@ export type communityResponseProps = {
 
 //추가
 export type communityResponseDetailProps = {
-  posts: CommunitiesProps[];
+  posts: CommunityApiProps[];
   totalPosts: number;
   hasMore: boolean;
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,16 @@ export const logger = {
   log: (...args: unknown[]) => console.log("[LOG]", ...args),
   error: (...args: unknown[]) => console.error("[ERROR]", ...args),
 };
+
+
+// ISO 8601 문자열 → KST 기준 "YYYY-MM-DD" 반환
+// 예: "2026-01-01T00:00:00.000Z" → "2026-01-01"
+export function formatKST(isoString: string): string {
+  const kst = new Date(
+    new Date(isoString).toLocaleString("en-US", { timeZone: "Asia/Seoul" })
+  );
+  const y = kst.getFullYear();
+  const m = String(kst.getMonth() + 1).padStart(2, "0");
+  const d = String(kst.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}


### PR DESCRIPTION
**mock 기반 repo 도입 및 카테고리 도메인 구조 정리**
-

<h3>[배경]</h3>

- 백엔드 이탈로 인해 커뮤니티 list / detail / create 기능을 통합적으로 검증할 수 없는 상태
- list/detail은 mock builder 기반으로 렌더링되고 있었으나, create는 localStorage에 저장되는 구조라 데이터 소스가 분리되어 있었음
- 이로 인해 작성한 게시글이 detail/list 화면에 반영되지 않아 사용자 플로우가 단절되는 문제가 발생
- 또한 카테고리 정의가 여러 파일에 분산되어 있어 중복 및 불일치 가능성이 존재

<h3>[문제]</h3>

<b>1. 데이터 소스 불일치</b>
- create는 localStorage 기반, list/detail은 builder 또는 서버 호출 기반으로
  작성한 글이 detail에서 보이지 않는 구조적 문제 발생

<b>2. 카테고리 정의 중복</b>
- CATEGORIES/KEY_TO_CATEGORYNAME/CATEGORY_NAMES/도메인 타입이
  여러 곳에서 각각 정의되어 있었음

<b>3. 타입 안정성 부족</b>
- categoryName이 string 타입으로 선언되어 잘못된 값이 컴파일 단계에서 차단되지 않음

<b>4. 모듈 의존성 문제</b>
- mock.server 파일을 직접 import하여 구현체에 강하게 의존

<b>5. createdAt 표시 버그</b>
- ISO 8601 문자열에 공백이 없어 split(" ")[0]이 전체 문자열을 그대로 노출

<b>6. seed 데이터 부족</b>
- 10개 고정으로 무한스크롤 체험 불가


<h3>[작업 내용]</h3>

<b>1. 데이터 소스 레이어 분리 (Repository 도입)</b>
- communityRepo.client.ts를 추가하여 localStorage 기반 저장소를 하나의 레이어로 통합
- seed 1회 주입 구조(SEEDED_KEY) 도입
- toListItem() 변환 함수를 통해 detail ↔ list 모델 차이를 repo에서 흡수
- UI는 repo만 바라보도록 구조 정리

<b>2. 카테고리 구조 단일화</b>
- category 관련 상수를 constants/categories.ts로 통합
- CATEGORY_NAMES literal tuple 기반으로 CategoryName union 타입 도출
- 중복 정의 제거
- KEY_TO_CATEGORYNAME 타입을 구체화하여 매핑 안정성 강화

<b>3. 도메인 모델 정비</b>
- CommunityProps, CommunitiesProps를 API 타입 기반으로 재구성
- Omit<...>을 활용하여 API 타입과 도메인 타입 경계를 명확히 분리
- categoryName을 union 타입으로 강제하여 컴파일 단계에서 오류 방지

<b>4. 입력 검증 및 런타임 안정성 개선</b>
- FormData 처리 시 categoryType 검증 로직 추가
- 잘못된 카테고리 값 차단
- create 흐름에서 발생하던 category key 오타 수정
- createdAt을 ISO 형식으로 통일하여 날짜 포맷 표준화

<b>5. 모듈 의존성 정리</b>
- mock.server 직접 import 제거
- community API entry point를 통한 import 구조로 변경
- 추후 mock ↔ real 전환 시 변경 범위 최소화

<b>6. createdAt 표시 정상화</b>
- formatKST() 유틸 추가(src/utils/index.ts)
- ISO 8601 → KST 기준 YYYY-MM-DD 변환
- CategoryFilter.tsx의 split(" ")[0] 버그 수정

<b>7. 무한스크롤 복구</b>
- seed 데이터를 10개 고정(buildCommunityList 의존)에서 
  35개 직접 생성(Array.from + buildCommunityDetail)으로 교체
- listPage(categoryKey, page, pageSize) 기반 pagination repo에서 담당

<b>8. 타입 정합성 수정</b>
- communityResponseDetailProps.posts를 CommunitiesProps[]에서 CommunityApiProps[]로 변경. 
- Zod 스키마(categoryName: z.string())와 타입 선언 불일치로 인한 Vercel 빌드 오류 수정

<b>9. detail 데이터 소스 통합</b>
- page.tsx 서버 fetch 제거, clientPage.tsx가 getPost()로 localStorage에서 직접 로드.
- categoryName/viewCnt/likesCnt가 list와 동일한 값으로 표시

<b>10. detail·댓글 createdAt formatKST 적용</b>
- clientPage.tsx, Comment.tsx에 formatKST 추가

<b>11.Zod transform으로 categoryName 타입 안전성 강화</b>
- communitySchema, communityDetailSchema의 categoryName을 z.string().transform(toCategoryName)으로 변경.
- 서버에서 임의 string이 와도 안전하게 CategoryName으로 변환

<h3>[결과 및 개선]</h3>

- 백엔드 없이도 create → detail → list 흐름이 일관되게 동작
- 카테고리/인기글 필터 정상 복구
- 카테고리 정의의 단일 진실 원천(SSOT: Single Source of Truth) 확보
- 컴파일 단계 타입 안정성 향상
- 도메인 모델과 API 모델 간 경계 명확화
- createdAt 날짜 KST 기준 YYYY-MM-DD 형식으로 정상 표시
- 무한스크롤 35개 seed 기반으로 정상 동작
- 추후 서버 연동을 고려한 구조로 정비 완료(mock → real 서버 전환 대비 구조 확보)

<h3>[검증]</h3>

- /community/posts/list?category=none&page=0 정상 동작 확인
- category=popular 필터 정상 작동 확인
- 각 카테고리별 필터링 정상 확인
- create 후 detail 이동 시 작성 글 즉시 반영 확인
- createdAt 2026-01-01 형식 정상 표시 확인
- 무한스크롤 35개 → 페이지 이동 정상 동작 확인
- detail 진입 시 list와 동일한 categoryName/viewCnt/likesCnt 표시 확인
- detail·댓글 createdAt YYYY-MM-DD 형식 표시 확인
- Vercel 빌드 정상 완료 확인

</br> 

<h3>[할 일]</h3> 

- [x] Detail Route Handler + 화면 정상화
- [ ] Home Route Handler + 첫 화면 정상화
- [ ] Search Route Handler(query 기반) + 타이핑 데모 가능하게
- [ ] (여유 있으면) Create POST Route Handler로 연동 
- [x] listPage(categoryKey, page, pageSize) 구현으로 무한스크롤 복구
- [x] 뒤로가기 시 page/scroll 복원 전략 설계
- [x] 카테고리 한글 라벨과 내부값 분리 구조 정리