### PR TITLE
Feat: README 작성 및 UX 개선 (lesson 활성화, 최근 검색어, toast)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,223 +1,140 @@
-# 로그인
+# 🏊 Dive In — 수영 클래스 통합 조회 플랫폼
 
-## 1. (프론트) 로그인 페이지
+**Dive + In** 의 합성어로, 수영에 진심인 스위머(swimmer)들이 깊게 다이빙하여 뛰어든다는 뜻입니다.
 
-> `https://dive-in.co.kr/login`
+여기저기 흩어져 있던 수영 클래스 정보를 한 눈에 확인할 수 있는 통합 조회 플랫폼입니다.
 
-로그인 페이지에서 “카카오로 로그인하기” 버튼을 누르면, 카카오 로그인 페이지로 이동합니다.
+**배포 링크**: [dive-in-web-vercel-deploy-8vor-7855qu2ia.vercel.app](https://dive-in-web-vercel-deploy-8vor-7855qu2ia.vercel.app)
 
-```tsx
-Kakao.Auth.autorize({
-  redirectUri: "https://dive-in.co.kr/api/auth/callback",
-  scope: "openid",
-});
+---
+
+## 📌 프로젝트 배경
+
+수영 클래스 정보를 찾을 때 어려움을 느낀다고 응답한 사용자가 **116명 중 58.5%** 에 달했습니다.
+
+> "수영 클래스 정보가 여기저기 다 흩어져 있어서 진짜 헷갈려요!"
+> "원하는 시간대나 조건 맞는 클래스를 찾기가 정말 힘들어요"
+> "강사 정보가 부족해서 누구한테 배워야 할지 고민돼요"
+
+이 문제를 해결하기 위해 수영 클래스, 수영장, 커뮤니티 정보를 한 곳에서 확인할 수 있는 서비스를 기획했습니다.
+
+---
+
+## 👥 팀 구성 및 기간
+
+| 역할 | 인원 |
+|------|------|
+| 서비스 기획 | 2명 |
+| 디자인 | 1명 |
+| 프론트엔드 | 1명 (본인) |
+| 백엔드 | 1명 |
+
+**팀 프로젝트 기간**: 2024.12 ~ 2025.05
+**개인 프로젝트 전환**: 2026.02 ~ 현재
+
+> 팀 프로젝트로 시작해 약 6개월간 개발했으나, 이후 개인 프로젝트로 전환하여 Mock 인프라를 직접 구축했습니다.
+
+---
+
+## 📸 데모
+
+> 추후 GIF 추가 예정
+
+---
+
+## ✨ 핵심 기능
+
+| 버전 | 기능 | 설명 |
+|------|------|------|
+| v1.0 | 수영 클래스 | 흩어져 있던 수영 클래스를 한눈에 확인. 난이도, 강사, 가격, 신청 링크 제공 |
+| v1.0 | 수영장 | 수영장 정보 및 위치 확인, 카카오맵 길찾기 연동 |
+| v1.5 | 마이페이지 | 내 정보 확인 및 프로필 관리, 수영코칭팀/강사 등록 |
+| v2.0 | 커뮤니티 | 카테고리별 게시글 작성·조회·댓글, 무한스크롤, OG 링크 미리보기 |
+| v2.5 | 통합검색 | 클래스·수영장·커뮤니티 통합 검색, 디바운싱 + Zustand 전역 상태 관리 |
+
+---
+
+## 🛠 기술 스택
+
+| 분류 | 기술 | 선택 이유 |
+|------|------|----------|
+| Framework | Next.js 14 (App Router) | 서버 컴포넌트와 Route Handler로 클라이언트/서버 역할을 명확히 분리 |
+| Language | TypeScript | API 응답 타입을 Zod로 검증하고 컴파일 타임에 타입 오류 방지 |
+| Styling | Tailwind CSS | 유틸리티 클래스 기반 빠른 UI 구성 |
+| Validation | Zod | API 경계에서 런타임 타입 검증 및 transform으로 안전한 데이터 처리 |
+| 상태 관리 | Zustand | 검색 상태를 여러 컴포넌트에서 공유하고 props drilling 없이 접근 |
+| 인증 | Kakao OAuth | 소셜 로그인 UX 제공 |
+
+---
+
+## 🏗 아키텍처
+
+### Mock / Real API 전환 구조
+
+백엔드 서버 이탈 후 `NEXT_PUBLIC_USE_MOCK` 환경변수 하나로 mock과 real API를 전환할 수 있는 구조를 설계했습니다.
+
+```
+src/api/server/community/
+├── index.ts        # USE_MOCK 분기 — mock/real 중 하나를 re-export
+├── real.ts         # 외부 API 호출 (api.dive-in.co.kr)
+├── mock.server.ts  # 서버사이드 읽기 (getCommunities, getCommunity)
+└── mock.client.ts  # 클라이언트 쓰기 (createCommunity → localStorage)
 ```
 
-## 2. (외부) 카카오 로그인 페이지
+Mock 환경에서는 `localStorage`를 데이터 저장소로 사용합니다. seed 데이터 35개가 자동으로 생성되며 `SEEDED_KEY`로 중복 seed를 방지합니다.
 
-카카오 계정을 입력하여 로그인합니다.
+### 페이지 구조 패턴
 
-카카오 로그인이 성공적으로 이루어진 경우, `redirectUri` 에 code를 파라미터로 추가하여 리다이렉트합니다.
-
-## 3. 리다이렉트
-
-### 3-1. (프론트) 리다이렉트 페이지
-
-> `https://dive-in.co.kr/api/auth/callback`
-
-```tsx
-export async function GET(request: Request) {
-  const { searchParams, origin } = new URL(request.url);
-  const code = searchParams.get("code");
-
-  // code가 없는 경우, 에러
-  if (!code) {
-    return NextResponse.redirect(`${origin}/auth/login?error=invalid_code`);
-  }
-
-  // 1. 백엔드로 code와 redirect_uri를 전달하여, 로그인을 요청합니다. (3-2로 이동합니다)
-  const url = new URL(`http://localhost:8080/login/kakao`);
-  url.searchParams.append("code", code);
-  url.searchParams.append("redirect_uri", `${origin}/api/auth/callback`);
-  const res = await fetch(url);
-
-  if (!res.ok) {
-    return NextResponse.redirect(`${origin}/auth/login?error=failed_to_login`);
-  }
-
-  const { access_token, refresh_token } = await res.json();
-
-  // (3-2에서 이어집니다)
-  // 2. 백엔드에서 응답받은 token을 쿠키에 삽입하여, 회원가입/로그인을 완료합니다.
-  return NextResponse.redirect(`${origin}`, {
-    headers: [
-      [
-        "Set-Cookie",
-        `access_token=${access_token}; Path=/; HttpOnly; SameSite=Strict`,
-      ],
-      [
-        "Set-Cookie",
-        `refresh_token=${refresh_token}; Path=/; HttpOnly; SameSite=Strict`,
-      ],
-    ],
-  });
-}
+```
+page.tsx (Server Component)
+  └── clientPage.tsx (Client Component)
+        └── _components/ (코로케이션 컴포넌트)
 ```
 
-### 3-2. (백엔드) 로그인 페이지
+서버 컴포넌트에서 데이터를 fetch하고 클라이언트 컴포넌트에 props로 전달합니다. 인터랙션(필터링, 무한스크롤, 폼)은 클라이언트 컴포넌트에서 처리합니다.
 
-> `http://localhost:8080/login/kakao?code={code}&redirect_uri={redirect_uri}`
+### Route Handler 활용
 
-1. `code`와 `redirect_uri`를 이용하여, `token`을 요청합니다.
-2. 발급받은 `token`을 이용해 사용자 정보를 가져옵니다.
-3. 사용자 정보의 이메일을 이용하여, 회원가입과 로그인 로직을 분기합니다.
-   - 회원가입
-     1. 사용자 정보를 Member 테이블에 저장하고, jwt 토큰을 발급합니다.
-   - 로그인
-     1. 이메일을 이용하여, 사용자 정보를 Member 테이블에서 불러옵니다.
-4. TokenManager 테이블에 데이터를 저장합니다.
-5. access_token과 refresh_token을 반환합니다.
+외부 API 호출 시 발생하는 CORS 문제와 서버 액션 남용을 Route Handler로 해결했습니다.
 
-- 프론트 코드 예시
+| Route Handler | 역할 |
+|--------------|------|
+| `/api/og?url=` | 외부 URL OG 메타태그 서버사이드 파싱 (CORS 우회) |
+| `/api/search?keyword=` | Mock: 빌더 기반 키워드 필터링 / Real: 외부 API 프록시 |
 
-  ```tsx
-  import { NextRequest, NextResponse } from "next/server";
+---
 
-  const REST_API_KEY = process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY!;
-  const KAKAO_CLIENT_SECRET = process.env.KAKAO_CLIENT_SECRET!;
+## 📁 폴더 구조
 
-  export const GET = async (request: NextRequest) => {
-    const { searchParams } = request.nextUrl;
-    const code = searchParams.get("code");
-    const redirectUri = searchParams.get("redirect_uri");
-
-    // 1. code가 없다면, 400 에러를 반환합니다.
-    if (!code || !redirectUri) {
-      return NextResponse.json({ error: "invalid_code" }, { status: 400 });
-    }
-
-    // 2. code를 이용해 Kakao API로부터 access_token을 발급받습니다.
-    const tokenResponse = await getAccessToken(code, redirectUri);
-
-    if (!tokenResponse.ok) {
-      return NextResponse.json({ error: "failed_to_login" }, { status: 400 });
-    }
-
-    const token = await tokenResponse.json();
-
-    // 3. 발급받은 토큰을 이용해 사용자 정보를 가져옵니다.
-    const userResponse = await getUser(token.access_token);
-
-    if (!userResponse.ok) {
-      return NextResponse.json(
-        { error: "failed_to_get_user" },
-        { status: 400 }
-      );
-    }
-
-    const user = await userResponse.json();
-
-    // 4. 사용자 정보를 DB에 저장하고, jwt 토큰을 발급합니다.
-    const { userId } = await saveUser(user);
-    const { access_token, refresh_token } = await issueToken(user);
-
-    // 5. DB에 refresh_token을 저장합니다.
-    await saveRefreshToken(userId, refresh_token);
-
-    // 6. 응답에 access_token과 refresh_token을 담아 반환합니다.
-    return NextResponse.json({ access_token, refresh_token });
-  };
-
-  async function getAccessToken(code: string, redirectUri: string) {
-    const url = new URL("https://kauth.kakao.com/oauth/token");
-    url.searchParams.append("grant_type", "authorization_code");
-    url.searchParams.append("client_id", REST_API_KEY);
-    url.searchParams.append("redirect_uri", redirectUri);
-    url.searchParams.append("code", code);
-    url.searchParams.append("client_secret", KAKAO_CLIENT_SECRET);
-
-    return fetch(url.toString(), {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
-    });
-  }
-
-  async function getUser(accessToken: string) {
-    return fetch("https://kapi.kakao.com/v2/user/me", {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
-  }
-
-  async function saveUser(user: any) {
-    // ...
-    return { userId: 1 };
-  }
-
-  async function issueToken(user: any) {
-    // ...
-    return {
-      access_token: "access_token",
-      refresh_token: "refresh_token",
-    };
-  }
-
-  async function saveRefreshToken(userId: number, refreshToken: string) {
-    // ...
-  }
-  ```
-
-# 내 정보 가져오기
-
-> `GET` `api.dive-in.co.kr/me`
-
-- 백엔드 로직
-  1. access_token 유효성 체크
-     1. refresh_token 유효성 체크
-  2. token의 memberId를 이용하여 DB 검색 후 반환
-
-## 요청 (Request)
-
-### Cookie
-
-- access_token
-- refresh_token
-
-## 응답 (Response)
-
-### body
-
-```json
-{
-  "id": 1,
-  "email": "figma@kakao.com",
-  "nickname": "김병훈",
-  "role": "강사"
-}
+```
+src/
+├── app/                  # Next.js App Router 페이지 및 Route Handler
+│   ├── api/              # Route Handler (og, search, auth 등)
+│   └── community/        # 커뮤니티 관련 페이지
+├── api/server/           # API 레이어 (mock/real 분기)
+├── lib/community/        # Mock 데이터 빌더 및 localStorage CRUD
+├── store/                # Zustand 전역 상태
+├── schemas/              # Zod 스키마
+├── types/                # z.infer 기반 타입
+└── constants/            # 카테고리 등 상수
 ```
 
-# 로그아웃
+---
 
-> `POST` `api.dive-in.co.kr/logout`
+## 🚀 로컬 실행
 
-- 백엔드 로직
-  1. refresh_token 유효성 검증
-  2. DB에서 TokenManager row 삭제
-
-## 요청 (Request)
-
-### body
-
-```json
-{
-  "access_token": "abcd",
-  "refresh_token": "zxcv"
-}
+```bash
+npm install
+npm run dev
 ```
 
-## 응답 (Response)
+**환경변수 설정** (`.env.local`):
 
-없음
+```env
+NEXT_PUBLIC_USE_MOCK=true
+NEXT_PUBLIC_KAKAO_APP_KEY=your_key
+NEXT_PUBLIC_KAKAO_REST_API_KEY=your_key
+KAKAO_CLIENT_SECRET=your_secret
+```
+
+> `NEXT_PUBLIC_USE_MOCK=true` 설정 시 외부 API 없이 Mock 데이터로 동작합니다.

--- a/src/api/server/lessons.ts
+++ b/src/api/server/lessons.ts
@@ -1,8 +1,13 @@
 "use server";
 
 import { lessonDetailSchema, lessonSchema } from "@/schemas/lessons";
+import { getMockLesson, mockLessonList } from "@/lib/home/mockLessonsData";
+
+const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK === "true";
 
 export const getLessons = async () => {
+  if (USE_MOCK) return mockLessonList;
+
   try {
     const response = await fetch("https://api.dive-in.co.kr/lessons");
     const body = await response.json();
@@ -15,6 +20,8 @@ export const getLessons = async () => {
 };
 
 export const getLesson = async (id: number) => {
+  if (USE_MOCK) return getMockLesson(id);
+
   try {
     const response = await fetch(`https://api.dive-in.co.kr/lessons/${id}`);
     const body = await response.json();

--- a/src/app/clientPage.tsx
+++ b/src/app/clientPage.tsx
@@ -91,9 +91,10 @@ export default function HomeClient({ home }: { home: HomeProps }) {
         {/* 카드리스트 */}
         <div className="grid grid-cols-2 gap-6 px-8 py-1">
           {popularLessons.map((lesson) => (
-            <div
+            <Link
               key={lesson.id}
-              className="p-6 rounded-lg shadow-sm bg-gray-100 flex flex-col h-full opacity-60 cursor-not-allowed"
+              href={`/lessons/${lesson.id}`}
+              className="p-6 rounded-lg shadow-sm bg-gray-100 flex flex-col h-full hover:bg-gray-200 transition-colors"
             >
               {/* 카드 1*/}
               <div className="flex flex-wrap gap-2 items-center pb-2">
@@ -112,7 +113,7 @@ export default function HomeClient({ home }: { home: HomeProps }) {
                   name={lesson.instructorName}
                 />
               </div>
-            </div>
+            </Link>
           ))}
         </div>
       </section>
@@ -127,9 +128,10 @@ export default function HomeClient({ home }: { home: HomeProps }) {
         {/* 카드리스트 */}
         <div className="grid grid-cols-2 gap-6 px-8 py-1">
           {NewLessons.map((lesson) => (
-            <div
+            <Link
               key={lesson.id}
-              className="p-6 rounded-lg shadow-sm bg-gray-100 flex flex-col h-full opacity-60 cursor-not-allowed"
+              href={`/lessons/${lesson.id}`}
+              className="p-6 rounded-lg shadow-sm bg-gray-100 flex flex-col h-full hover:bg-gray-200 transition-colors"
             >
               {/* 카드 1*/}
               <div className="flex flex-wrap gap-2 items-center pb-2">
@@ -148,7 +150,7 @@ export default function HomeClient({ home }: { home: HomeProps }) {
                   name={lesson.instructorName}
                 />
               </div>
-            </div>
+            </Link>
           ))}
         </div>
       </section>

--- a/src/app/community/posts/[id]/clientPage.tsx
+++ b/src/app/community/posts/[id]/clientPage.tsx
@@ -49,7 +49,8 @@ export default function ClientCommunity({ postId }: { postId: number }) {
   // console.warn("코멘트 안오냐?:::::::::::", community.commentList);
 
   //og관련
-  const [preview, setPreview] = useState<any>(null);
+  type OgPreview = { title: string; description: string; image: string | null; url: string };
+  const [preview, setPreview] = useState<OgPreview | null>(null);
   const urlRegex = /(https?:\/\/[^\s]+)/g; //OG추출을 위한 정규표현식
   useEffect(() => {
     if (!community?.content) return;

--- a/src/app/community/posts/[id]/edit/page.tsx
+++ b/src/app/community/posts/[id]/edit/page.tsx
@@ -13,6 +13,7 @@ import {
   updateCommunity,
 } from "@/api/server/community/mock.server";
 import { useRouter } from "next/navigation";
+import toast from "react-hot-toast";
 import OpenGraphPreview from "@/app/_components/OpenGraphLinkReview";
 
 // const CATEGORIES = ["소통해요", "수영장", "수영물품", "수영대회"];
@@ -44,7 +45,8 @@ export default function EditPost({ params }: EditPostProps) {
 
   const [isLinkOpen, setIsLinkOpen] = useState(false);
   const [link, setLink] = useState("");
-  const [preview, setPreview] = useState<any>(null); //OG데이터
+  type OgPreview = { title: string; description: string; image: string | null; url: string };
+  const [preview, setPreview] = useState<OgPreview | null>(null); //OG데이터
   // const [ogContent, setOgContent] = useState("");
   const containerRef = useRef<HTMLDivElement | null>(null);
   const router = useRouter();
@@ -137,7 +139,7 @@ useEffect(() => {
       (category) => category.name === selectedCategory
     );
     if (!category) {
-      alert("카테고리를 선택해주세요!");
+      toast.error("카테고리를 선택해주세요!");
       return;
     }
 
@@ -175,7 +177,7 @@ useEffect(() => {
       }
     } catch (err) {
       console.error(err);
-      alert("글 수정 실패");
+      toast.error("글 수정에 실패했습니다.");
     }
   };
 
@@ -189,7 +191,7 @@ useEffect(() => {
 
     const selectedFiles = Array.from(e.target.files); //선택파일 배열변환
     if (existImages.length + newImages.length >= 5) {
-      alert("이미지는 최대 5장까지 업로드 가능합니다.");
+      toast.error("이미지는 최대 5장까지 업로드 가능합니다.");
       return;
     }
 
@@ -231,7 +233,7 @@ useEffect(() => {
 
       // if(!og || !og.title){
       if (!og) {
-        alert("유효한 링크가 아닙니다.");
+        toast.error("유효한 링크가 아닙니다.");
         return;
       } else if (!og.title && !og.description && !og.image) {
         setPreview({
@@ -255,7 +257,7 @@ useEffect(() => {
       setIsLinkOpen(false);
     } catch (error) {
       console.error("오픈그래프 불러오기 실패:::", error);
-      alert("오픈그래프 정보를 불러올 수 없습니다.");
+      toast.error("오픈그래프 정보를 불러올 수 없습니다.");
     }
   };
 

--- a/src/app/community/posts/page.tsx
+++ b/src/app/community/posts/page.tsx
@@ -10,6 +10,7 @@ import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import OpenGraphPreview from "@/app/_components/OpenGraphLinkReview";
 import { createCommunity } from "@/api/server/community";
+import toast from "react-hot-toast";
 
 // const CATEGORIES = ["소통해요", "수영장", "수영물품", "수영대회"];
 const CATEGORIES = [
@@ -31,7 +32,8 @@ export default function CreatePost() {
 
   const [isLinkOpen, setIsLinkOpen] = useState(false);
   const [link, setLink] = useState("");
-  const [preview, setPreview] = useState<any>(null); //OG데이터
+  type OgPreview = { title: string; description: string; image: string | null; url: string };
+  const [preview, setPreview] = useState<OgPreview | null>(null); //OG데이터
   // const [ogContent, setOgContent] = useState("");
   const router = useRouter();
 
@@ -57,7 +59,7 @@ export default function CreatePost() {
       (category) => category.name === selectedCategory
     )?.key;
     if (!selectedCategoryKey) {
-      alert("카테고리를 선택해주세요!");
+      toast.error("카테고리를 선택해주세요!");
       return;
     }
     formData.append("categoryType", selectedCategoryKey);
@@ -102,7 +104,7 @@ export default function CreatePost() {
 
     const selectedFiles = Array.from(e.target.files); //선택파일 배열변환
     if (images.length + selectedFiles.length > 5) {
-      alert("이미지는 최대 5장까지 업로드 가능합니다.");
+      toast.error("이미지는 최대 5장까지 업로드 가능합니다.");
       return;
     }
     setImages((prev) => [...prev, ...selectedFiles]); //이미지추가
@@ -124,7 +126,7 @@ export default function CreatePost() {
       const og = await res.json();
 
       if (og.error) {
-        alert("유효한 링크가 아닙니다.");
+        toast.error("유효한 링크가 아닙니다.");
         return;
       } else if (!og.title && !og.description && !og.image) {
         setPreview({
@@ -148,7 +150,7 @@ export default function CreatePost() {
       setIsLinkOpen(false);
     } catch (error) {
       console.error("오픈그래프 불러오기 실패:::", error);
-      alert("오픈그래프 정보를 불러올 수 없습니다.");
+      toast.error("오픈그래프 정보를 불러올 수 없습니다.");
     }
   };
 

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -9,25 +9,34 @@ import { getSearch } from "@/api/server/search";
 import BackButton from "../_components/backButton";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useSearchStore } from "@/store/searchStore";
+import { IoCloseOutline } from "react-icons/io5";
 
 export default function ClientSearch() {
-  const { keyword, results: result, setKeyword, setResults } = useSearchStore();
+  const {
+    keyword,
+    results: result,
+    recentKeywords,
+    setKeyword,
+    setResults,
+    addRecentKeyword,
+    removeRecentKeyword,
+    clearRecentKeywords,
+  } = useSearchStore();
   const debounceKeyword = useDebounce(keyword, 300); //디바운싱 적용된 입력값
 
   useEffect(() => {
     const fetchSearch = async () => {
       if (!debounceKeyword.trim()) {
-        setResults([]); //검색창이 비면 결과 비우기
-        return; //함수 종료(빈문자열로 api요청 안보내도록 무시/fetch요청 막기)
+        setResults([]);
+        return;
       }
 
       try {
         const data = await getSearch(debounceKeyword);
-
         if (data) {
           setResults(data);
+          addRecentKeyword(debounceKeyword);
         }
-
       } catch (error) {
         console.error("검색 결과 에러:::", error);
       }
@@ -57,48 +66,72 @@ export default function ClientSearch() {
             autoFocus
             onChange={(e) => setKeyword(e.target.value)}
           />
-          {/* <button
-            type="submit"
-            className="flex-none flex items-center justify-center bg-gray-100 w-10 h-10"
-          >
-            <SearchIcon className="w-5 h-5" />
-          </button> */}
         </form>
       </div>
-      
-      <div>
-        <div>
-          {/* <p className="p-4">클라이언트 페이지</p> */}
-          <ul className="list-none px-4">
-            {result.map((result) => (
-              // <li key={result.id} className="border-b border-gray-300 pb-4">
-              <li className="border-b border-gray-300 pb-4">
-                <Link href={result.dataUrl} className="flex p-3">
-                  <div className="flex flex-col items-start bg-white-100 rounded-lg mt-4">
-                    <div className="flex flex-row">
-                      {getCategoryIcon(result.categoryName)}
-                      <div
-                        className={`text-label_sb py-1 rounded text-chip-1-foreground inline-block w-fit`}
-                      >
-                        <p className="pl-2">{result.categoryName}</p>
-                      </div>
-                    </div>
-                    <p className="text-md pl-8">{result.title}</p>
-                    <p className="text-sm text-gray-600 pl-8">
-                      {result.content}
-                    </p>
-                    <p className="text-sm text-gray-600 pl-8">
-                      {result.contentSummary}
-                    </p>
-                    <p className="text-sm text-gray-600 pl-8">
-                      {result.createdAt}
-                    </p>
-                  </div>
-                </Link>
+
+      {/* 최근 검색어 — 검색창이 비어있을 때만 표시 */}
+      {!keyword.trim() && recentKeywords.length > 0 && (
+        <div className="px-4 pt-4">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-sm font-bold text-gray-700">최근 검색어</span>
+            <button
+              onClick={clearRecentKeywords}
+              className="text-xs text-gray-400 hover:text-gray-600"
+            >
+              전체 삭제
+            </button>
+          </div>
+          <ul className="flex flex-col gap-1">
+            {recentKeywords.map((kw) => (
+              <li key={kw} className="flex items-center justify-between py-1">
+                <button
+                  className="text-sm text-gray-700 hover:text-blue-900 text-left"
+                  onClick={() => setKeyword(kw)}
+                >
+                  {kw}
+                </button>
+                <button
+                  onClick={() => removeRecentKeyword(kw)}
+                  className="text-gray-400 hover:text-gray-600"
+                >
+                  <IoCloseOutline className="w-4 h-4" />
+                </button>
               </li>
             ))}
           </ul>
         </div>
+      )}
+
+      {/* 검색 결과 */}
+      <div>
+        <ul className="list-none px-4">
+          {result.map((result) => (
+            <li className="border-b border-gray-300 pb-4">
+              <Link href={result.dataUrl} className="flex p-3">
+                <div className="flex flex-col items-start bg-white-100 rounded-lg mt-4">
+                  <div className="flex flex-row">
+                    {getCategoryIcon(result.categoryName)}
+                    <div
+                      className={`text-label_sb py-1 rounded text-chip-1-foreground inline-block w-fit`}
+                    >
+                      <p className="pl-2">{result.categoryName}</p>
+                    </div>
+                  </div>
+                  <p className="text-md pl-8">{result.title}</p>
+                  <p className="text-sm text-gray-600 pl-8">
+                    {result.content}
+                  </p>
+                  <p className="text-sm text-gray-600 pl-8">
+                    {result.contentSummary}
+                  </p>
+                  <p className="text-sm text-gray-600 pl-8">
+                    {result.createdAt}
+                  </p>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
       </div>
     </div>
   );

--- a/src/lib/home/mockLessonsData.ts
+++ b/src/lib/home/mockLessonsData.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import { lessonDetailSchema, lessonSchema } from "@/schemas/lessons";
+
+type Lesson = z.infer<typeof lessonSchema>;
+type LessonDetail = z.infer<typeof lessonDetailSchema>;
+
+export const mockLessonList: Lesson[] = [
+  { id: 1, academyName: "수달상회", academyImageUrl: "/empty/academy_profile.png", lessonName: "마스터즈 평일 교정 훈련 클래스", level: "고급", keyword: "접영,스타트", price: "월 150,000원" },
+  { id: 2, academyName: "이지스윔", academyImageUrl: "/empty/academy_profile.png", lessonName: "유소년 선수반", level: "초급,중급", keyword: "자유형,다이빙", price: "월 120,000원" },
+  { id: 3, academyName: "물곰TV", academyImageUrl: "/empty/academy_profile.png", lessonName: "성인 기초 수영 클래스", level: "초급", keyword: "배영,개인혼영", price: "월 90,000원" },
+  { id: 4, academyName: "4레인", academyImageUrl: "/empty/academy_profile.png", lessonName: "청소년 선수반", level: "중급", keyword: "접영,교정", price: "월 130,000원" },
+  { id: 5, academyName: "블루웨이브", academyImageUrl: "/empty/academy_profile.png", lessonName: "주말 집중 수영 트레이닝", level: "중급,고급", keyword: "자유형,체력", price: "월 110,000원" },
+  { id: 6, academyName: "아쿠아짐", academyImageUrl: "/empty/academy_profile.png", lessonName: "시니어 아쿠아로빅", level: "초급", keyword: "수중운동,건강", price: "월 80,000원" },
+];
+
+const mockDetail = (id: number): LessonDetail => ({
+  id,
+  lessonName: mockLessonList.find((l) => l.id === id)?.lessonName ?? "수영 클래스",
+  level: mockLessonList.find((l) => l.id === id)?.level ?? "초급",
+  capacity: "20명",
+  price: mockLessonList.find((l) => l.id === id)?.price ?? "가격 문의",
+  keyword: mockLessonList.find((l) => l.id === id)?.keyword ?? "",
+  lessonDetail: {
+    topic: "수영 기술 향상 및 체력 강화",
+    eligibilityRequirements: ["수영 기본기를 보유하신 분", "꾸준히 참여 가능하신 분"],
+    introduction: "전문 코치와 함께하는 체계적인 수영 클래스입니다. 개인 실력에 맞는 맞춤형 지도로 실력을 향상시켜 드립니다.",
+    applicationMethod: [{ applyUrl: "https://instagram.com", applyUrlType: "인스타그램" }],
+    refundPolicy: ["수업 3일 전 취소 시 전액 환불", "수업 당일 취소 시 환불 불가"],
+  },
+  lessonSchedule: "평일 오전 6:00 ~ 7:30 / 저녁 7:00 ~ 8:30",
+  lessonStatus: "모집중",
+  academy: {
+    id,
+    academyName: mockLessonList.find((l) => l.id === id)?.academyName ?? "수영 아카데미",
+    academyInfo: "전문 수영 코치진이 운영하는 수영 클래스입니다.",
+    profileImageUrl: "/empty/academy_profile.png",
+  },
+  pool: {
+    id,
+    poolName: "올림픽 수영장",
+    poolAddress: "서울 송파구 올림픽로 424",
+    region: "서울",
+    imageUrl: "/empty/image.png",
+    latitude: 37.5197,
+    longitude: 127.1219,
+  },
+  images: [],
+});
+
+export const getMockLesson = (id: number): LessonDetail | null => {
+  const exists = mockLessonList.some((l) => l.id === id);
+  if (!exists) return null;
+  return mockDetail(id);
+};

--- a/src/store/searchStore.ts
+++ b/src/store/searchStore.ts
@@ -1,16 +1,39 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 import { Search } from "@/types/search";
 
 type SearchState = {
   keyword: string;
   results: Search[];
+  recentKeywords: string[];
   setKeyword: (keyword: string) => void;
   setResults: (results: Search[]) => void;
+  addRecentKeyword: (keyword: string) => void;
+  removeRecentKeyword: (keyword: string) => void;
+  clearRecentKeywords: () => void;
 };
 
-export const useSearchStore = create<SearchState>((set) => ({
-  keyword: "",
-  results: [],
-  setKeyword: (keyword) => set({ keyword }),
-  setResults: (results) => set({ results }),
-}));
+export const useSearchStore = create<SearchState>()(
+  persist(
+    (set, get) => ({
+      keyword: "",
+      results: [],
+      recentKeywords: [],
+      setKeyword: (keyword) => set({ keyword }),
+      setResults: (results) => set({ results }),
+      addRecentKeyword: (keyword) => {
+        const trimmed = keyword.trim();
+        if (!trimmed) return;
+        const prev = get().recentKeywords.filter((k) => k !== trimmed);
+        set({ recentKeywords: [trimmed, ...prev].slice(0, 10) });
+      },
+      removeRecentKeyword: (keyword) =>
+        set({ recentKeywords: get().recentKeywords.filter((k) => k !== keyword) }),
+      clearRecentKeywords: () => set({ recentKeywords: [] }),
+    }),
+    {
+      name: "search-storage",
+      partialize: (state) => ({ recentKeywords: state.recentKeywords }),
+    }
+  )
+);


### PR DESCRIPTION
**README 작성 및 UX 개선 (lesson 활성화, 최근 검색어, toast)**
-

<h3>[P4의 내용]</h3>
<img width="1823" height="415" alt="image" src="https://github.com/user-attachments/assets/9ff2bbee-2187-47dc-9d87-b62d47332828" />


<h3>[배경]</h3>

- 프로젝트 README 신규 작성 (배경, 아키텍처, 기술 선택 이유 포함)
- 홈 수업 카드 클릭 활성화 및 lesson mock 데이터 구축
- Zustand searchStore 최근 검색어 기능 확장
- alert() → React Hot Toast 교체
- any 타입 제거

<h3>[문제]</h3>

 1. README 없음 → 면접관이 코드 보기 전 프로젝트 파악 불가
 2. 홈 수업 카드 클릭 불가 (opacity-60 cursor-not-allowed) → 미완성으로 보임
 3. Zustand store가 keyword/results만 관리 → 활용 범위 좁음
 4. alert() 9곳 사용 → UX 최하, 브라우저 기본 다이얼로그
 5. useState<any> 3개 잔류 → TypeScript 프로젝트 감점 요소

<h3>[작업 내용]</h3>

- README.md 
1. 프로젝트 배경(설문 58.5%)
2. 팀 구성
3. 기술 스택 + 선택 이유
4. 아키텍처(mock/real 분기, Route Handler)
5.  주요 기능 버전별 정리
  - mockLessonsData.ts 신규 — id 1~6 lesson list/detail mock 데이터
  - lessons.ts — NEXT_PUBLIC_USE_MOCK 분기 추가, mock 시 mockLessonsData 반환
  - clientPage.tsx (홈) — lesson 카드 div → Link(/lessons/:id) 복원, hover 효과 추가
  - searchStore.ts — recentKeywords / addRecentKeyword / removeRecentKeyword / clearRecentKeywords 추가, 
                                 persist 미들웨어로 localStorage 동기화 (최대 10개)
  - search/page.tsx — 검색창 비었을 때 최근 검색어 목록 표시, 클릭 시 검색, 개별/전체 삭제
  - alert() 9곳 → toast.error()로 교체
  - preview: any → OgPreview 타입으로 교체 (3개 파일)


<h3>[결과 및 개선]</h3>

- 홈 → 수업 카드 클릭 → detail 페이지 정상 이동
- 검색 후 재진입 시 최근 검색어 표시, 새로고침 후에도 유지
- 에러 메시지가 toast로 자연스럽게 표시

<h3>[검증/ 할 일]</h3>

- [ ] 홈 수업 카드 클릭 → /lessons/:id 정상 이동 확인
- [ ] 검색 후 다른 페이지 이동 → 재진입 시 최근 검색어 표시 확인
- [ ] 새로고침 후 최근 검색어 유지 확인 (persist)
- [ ] 글 작성 시 toast 정상 출력 확인
- [ ] Vercel 빌드 통과 확인
