### PR TITLE
Feat: edit 카테고리 한글 표시 및 create 폼 유효성 검사 추가

### DIFF
--- a/src/api/server/home.ts
+++ b/src/api/server/home.ts
@@ -4,7 +4,7 @@ import { homeResponseScheme } from "@/schemas/home";
 import { mockHomeData } from "@/lib/home/mockHomeData";
 
 export const getHome = async () => {
-  if (process.env.USE_MOCK === "true") {
+  if (process.env.NEXT_PUBLIC_USE_MOCK === "true") {
     return mockHomeData;
   }
 

--- a/src/app/community/posts/[id]/edit/page.tsx
+++ b/src/app/community/posts/[id]/edit/page.tsx
@@ -12,6 +12,7 @@ import {
   openGraph,
   updateCommunity,
 } from "@/api/server/community/mock.server";
+import { CATEGORYNAME_TO_LABEL } from "@/constants/categories";
 import { useRouter } from "next/navigation";
 import toast from "react-hot-toast";
 import OpenGraphPreview from "@/app/_components/OpenGraphLinkReview";
@@ -122,7 +123,7 @@ useEffect(() => {
 
         setTitle(post.title);
         setContent(post.content);
-        setSelectedCategory(post.categoryName || "소통해요");
+        setSelectedCategory(CATEGORYNAME_TO_LABEL[post.categoryName] || "소통해요");
         setExistImages(post.images);
       } catch (error) {
         console.error(error);

--- a/src/app/community/posts/[id]/edit/page.tsx
+++ b/src/app/community/posts/[id]/edit/page.tsx
@@ -7,15 +7,12 @@ import { MdOutlineBrokenImage } from "react-icons/md";
 import { AiOutlineLink } from "react-icons/ai";
 import { IoIosArrowDown } from "react-icons/io";
 import { useEffect, useRef, useState } from "react";
-import {
-  getCommunity,
-  openGraph,
-  updateCommunity,
-} from "@/api/server/community/mock.server";
+import { openGraph } from "@/api/server/community/mock.server";
 import { CATEGORYNAME_TO_LABEL } from "@/constants/categories";
 import { useRouter } from "next/navigation";
 import toast from "react-hot-toast";
 import OpenGraphPreview from "@/app/_components/OpenGraphLinkReview";
+import { getPost, updatePost } from "@/lib/community/communityRepo.client";
 
 // const CATEGORIES = ["소통해요", "수영장", "수영물품", "수영대회"];
 const CATEGORIES = [
@@ -116,7 +113,7 @@ useEffect(() => {
   useEffect(() => {
     const fetchPost = async () => {
       try {
-        const post = await getCommunity(postId);
+        const post = await getPost(Number(postId));
         if (!post) {
           throw new Error("게시글 수정 실패!");
         }
@@ -164,18 +161,14 @@ useEffect(() => {
     );
 
     try {
-      await updateCommunity(postId, formData);
+      await updatePost(Number(postId), {
+        title,
+        content,
+        categoryName: category.key as import("@/constants/categories").CategoryName,
+        images: existImages,
+      });
 
-      //최신 데이터 가져오기
-      const updatePost = await getCommunity(postId);
-      if (updatePost) {
-        setTitle(updatePost.title);
-        setContent(updatePost?.content);
-      }
-
-      if (postId) {
-        router.replace(`/community/posts/${postId}`);
-      }
+      router.replace(`/community/posts/${postId}`);
     } catch (err) {
       console.error(err);
       toast.error("글 수정에 실패했습니다.");

--- a/src/app/community/posts/page.tsx
+++ b/src/app/community/posts/page.tsx
@@ -30,6 +30,8 @@ export default function CreatePost() {
   const [images, setImages] = useState<File[]>([]);
   const fileInputRef = useRef<HTMLInputElement | null>(null); //input참조
 
+  const [isLoading, setIsLoading] = useState(false);
+  const isSubmittingRef = useRef(false);
   const [isLinkOpen, setIsLinkOpen] = useState(false);
   const [link, setLink] = useState("");
   type OgPreview = { title: string; description: string; image: string | null; url: string };
@@ -54,7 +56,9 @@ export default function CreatePost() {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const formData = new FormData();
+    if (isSubmittingRef.current) return;
+
+    // validation 먼저 — 실패 시 isLoading 건드리지 않음
     const selectedCategoryKey = CATEGORIES.find(
       (category) => category.name === selectedCategory
     )?.key;
@@ -62,37 +66,39 @@ export default function CreatePost() {
       toast.error("카테고리를 선택해주세요!");
       return;
     }
-    formData.append("categoryType", selectedCategoryKey);
 
     const title = e.currentTarget.querySelector<HTMLInputElement>("#title");
     if (!title || !title.value.trim()) {
       toast.error("제목을 입력해주세요!");
       return;
     }
-    formData.append("title", title.value.trim());
 
     if (!content.trim()) {
       toast.error("내용을 입력해주세요!");
       return;
     }
+
+    // validation 통과 후 제출
+    isSubmittingRef.current = true;
+    setIsLoading(true);
+    const formData = new FormData();
+    formData.append("categoryType", selectedCategoryKey);
+    formData.append("title", title.value.trim());
     formData.append("content", content);
-
-    //임시
-    const userId = "1";
-    formData.append("memberId", userId); //마이페이지 보고 가져오기
-
+    formData.append("memberId", "1");
     images.forEach((image) => {
       formData.append("images", image);
     });
 
     try {
       const postId = await createCommunity(formData);
-      if (postId) {
-        router.push(`/community/posts/${postId}`);
-      }
+      router.replace(`/community/posts/${postId}`);
     } catch (err) {
       console.error("글 작성 실패", err);
       toast.error("글 작성에 실패했습니다.");
+    } finally {
+      isSubmittingRef.current = false;
+      setIsLoading(false);
     }
   };
 
@@ -180,8 +186,8 @@ export default function CreatePost() {
         <h2 className="text-heading_3 font-bold text-center">글쓰기</h2>
         {/* <Link href={`/communities/${community.id}`} className="flex p-3"> */}
 
-        <button type="submit" form="createPostForm" className="flex p-3">
-          <IoCheckmark className="w-6 h-6 text-gray-400 hover:text-blue-900" />
+        <button type="submit" form="createPostForm" className="flex p-3" disabled={isLoading}>
+          <IoCheckmark className={`w-6 h-6 ${isLoading ? "text-gray-200" : "text-gray-400 hover:text-blue-900"}`} />
         </button>
       </div>
 

--- a/src/app/community/posts/page.tsx
+++ b/src/app/community/posts/page.tsx
@@ -65,13 +65,16 @@ export default function CreatePost() {
     formData.append("categoryType", selectedCategoryKey);
 
     const title = e.currentTarget.querySelector<HTMLInputElement>("#title");
-    if (title) {
-      formData.append("title", title.value);
-    } else {
-      console.error("제목이 입력되지 않았습니다");
+    if (!title || !title.value.trim()) {
+      toast.error("제목을 입력해주세요!");
       return;
     }
+    formData.append("title", title.value.trim());
 
+    if (!content.trim()) {
+      toast.error("내용을 입력해주세요!");
+      return;
+    }
     formData.append("content", content);
 
     //임시
@@ -89,6 +92,7 @@ export default function CreatePost() {
       }
     } catch (err) {
       console.error("글 작성 실패", err);
+      toast.error("글 작성에 실패했습니다.");
     }
   };
 

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -10,6 +10,7 @@ import BackButton from "../_components/backButton";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useSearchStore } from "@/store/searchStore";
 import { IoCloseOutline } from "react-icons/io5";
+import { formatKST } from "@/utils";
 
 export default function ClientSearch() {
   const {
@@ -111,11 +112,6 @@ export default function ClientSearch() {
                 <div className="flex flex-col items-start bg-white-100 rounded-lg mt-4">
                   <div className="flex flex-row">
                     {getCategoryIcon(result.categoryName)}
-                    <div
-                      className={`text-label_sb py-1 rounded text-chip-1-foreground inline-block w-fit`}
-                    >
-                      <p className="pl-2">{result.categoryName}</p>
-                    </div>
                   </div>
                   <p className="text-md pl-8">{result.title}</p>
                   <p className="text-sm text-gray-600 pl-8">
@@ -125,7 +121,7 @@ export default function ClientSearch() {
                     {result.contentSummary}
                   </p>
                   <p className="text-sm text-gray-600 pl-8">
-                    {result.createdAt}
+                    {formatKST(result.createdAt)}
                   </p>
                 </div>
               </Link>
@@ -139,13 +135,13 @@ export default function ClientSearch() {
 
 const getCategoryIcon = (categoryName: string) => {
   switch (categoryName) {
+    case "소통해요":
+      return <ChatIcon className="h-6 w-6 text-gray-400" />;
     case "수영장":
       return <PoolIcon className="h-6 w-6 text-gray-400" />;
-    case "수영수업":
+    case "수영물품":
       return <SwimHatIcon className="h-6 w-6 text-gray-400" />;
-    case "커뮤니티":
-      return <ChatIcon className="h-6 w-6 text-gray-400" />;
     default:
-      return <div></div>;
+      return <div className="h-6 w-6" />;
   }
 };

--- a/src/lib/community/communityRepo.client.ts
+++ b/src/lib/community/communityRepo.client.ts
@@ -112,6 +112,14 @@ export async function createPost(newPost: CommunityProps): Promise<number> {
   return newPost.postId;
 }
 
+export async function updatePost(postId: number, updates: Partial<CommunityProps>): Promise<void> {
+  const posts = await listPosts();
+  const idx = posts.findIndex((p) => Number(p.postId) === postId);
+  if (idx === -1) throw new Error("Post not found");
+  posts[idx] = { ...posts[idx], ...updates, updatedAt: new Date().toISOString() };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(posts));
+}
+
 export async function listPage(params: {
   categoryKey: CategoryKey;
   page: number;


### PR DESCRIPTION
**edit 카테고리 한글 표시 및 create 폼 유효성 검사 추가**
-

<h3>[P5의 내용]</h3>

**① 글 작성 form validation**  
    **현재 버그:** 제목·내용 없이 생성 버튼 눌러도 아무 반응 없이 그냥 제출됨
<img width="1734" height="178" alt="image" src="https://github.com/user-attachments/assets/4daabb89-de3b-4ad9-91df-470e205a5d50" />

 **<테스트 내용>**
<img width="1569" height="460" alt="image" src="https://github.com/user-attachments/assets/28ed6818-712b-453b-ace0-970e4ec89595" />

<br/>

**② edit 페이지 카테고리 한글 매핑**
<img width="1814" height="157" alt="image" src="https://github.com/user-attachments/assets/af30fb76-132a-46bb-8149-0e92f89b6c01" />

 **<테스트 내용>**
<img width="1819" height="442" alt="image" src="https://github.com/user-attachments/assets/53588d49-46fe-4f18-80b7-2e05ada2af3a" />


<br/>

<h3>[배경]</h3>

- P5 버그 수정 — 글 수정/작성 페이지에서 발견된 UX 버그 3건 수정

<h3>[문제]</h3>

<b>1. edit 페이지 카테고리 초기값이 영문으로 표시됨</b>
- post.categoryName은 "COMMUNICATION" 타입인데, selectedCategory는 "소통해요" 형태의 한글로 관리됨
- 매핑 없이 그대로 setState → 드롭다운에 "COMMUNICATION" 그대로 노출
- 내용 변경 없이 수정 버튼 누르면 카테고리 불일치로 "카테고리를 선택해달라" 토스트 발생

<b>2. create 페이지 제목/내용 미입력 시 아무 반응 없음</b>
- 빈 값 체크 없이 바로 createCommunity 호출 → 실패해도 사용자에게 안내 없음

<b>3. getHome()이 Vercel에서 mock 분기를 타지 못함</b>
- process.env.USE_MOCK은 서버 전용 env인데 Vercel에는 NEXT_PUBLIC_USE_MOCK=true만 설정되어 있음
- 결과적으로 홈 화면 mock 데이터 미적용

<b>4. create 페이지 버튼 중복 클릭 시 같은 글 여러 개 생성</b>
 - isLoading state만으로는 useState 비동기 특성상 빠른 클릭 차단 불가

<b>5. edit 페이지에서 내가 쓴 글이 아닌 다른 글 내용이 표시됨</b>
 - getCommunity(mock.server.ts)가 builder 반환 → localStorage 글과 불일치
 - updateCommunity가 실제 백엔드 호출 → mock 모드에서 항상 실패

<b>6. 글 작성 완료 후 뒤로가기 시 create 페이지로 돌아옴</b>

<b>7. 검색 결과 카테고리 영문 노출 / 아이콘 미표시 / 날짜 ISO 그대로 노출</b>


<h3>[작업 내용]</h3>

1. edit/page.tsx — CATEGORYNAME_TO_LABEL[post.categoryName] 매핑 후 setSelectedCategory 호출
2. posts/page.tsx — 제목/내용 빈값 체크 후 toast.error() 안내 및 조기 return. 글 작성 실패 시 toast 추가
3. home.ts — process.env.USE_MOCK → process.env.NEXT_PUBLIC_USE_MOCK으로 교체
4. posts/page.tsx — useRef로 제출 중 즉시 차단 (isSubmittingRef)
5. communityRepo.client.ts — updatePost() 신규 추가 (localStorage 직접 수정)
6. edit/page.tsx — getCommunity → getPost, updateCommunity → updatePost 교체
7. posts/page.tsx — router.replace(`/community/posts/${postId}`)로 교체
8. search/page.tsx — 카테고리 텍스트 제거, 아이콘 한글 라벨 매핑, formatKST 적용


<h3>[결과 및 개선]</h3>

- edit 페이지 진입 시 기존 카테고리가 한글로 올바르게 표시됨
- 변경 없이 저장해도 카테고리 정상 유지
- create 페이지에서 제목/내용 미입력 시 사용자에게 명확한 안내 제공
- Vercel 환경에서 홈 화면 mock 데이터 정상 노출

<h3>[검증]</h3>

- edit 페이지 진입 시 카테고리 한글 표시 확인
- 내용 변경 없이 수정 저장 시 정상 동작 확인
- create 페이지 제목/내용 빈값 제출 시 toast 노출 확인
- Vercel 빌드 후 홈 화면 mock 데이터 노출 확인

<h3>[할 일]</h3>

- [x] 홈 수업 카드 클릭 → /lessons/:id 정상 이동 확인
- [x] 검색 후 다른 페이지 이동 → 재진입 시 최근 검색어 표시 확인
- [x] 새로고침 후 최근 검색어 유지 확인 (persist)
- [x] 글 작성 시 toast 정상 출력 확인
- [x] Vercel 빌드 통과 확인
- [ ] 좋아요 / 댓글 / 게시글 수정·삭제 mock 연결 (P5 선택 작업)
- [ ] 데모 GIF 촬영 후 README에 추가
