### PR TITLE
Feat: Mock 상호작용 연결 및 검색 UX 개선

### DIFF
--- a/src/api/server/community/index.ts
+++ b/src/api/server/community/index.ts
@@ -8,15 +8,3 @@ export const getCommunities = useMock? mockServer.getCommunities : real.getCommu
 export const getCommunity = useMock? mockServer.getCommunity : real.getCommunity;
 export const getComments = useMock? mockServer.getComments : real.getComments;
 export const createCommunity = useMock ? mockClient.createCommunity : real.createCommunity;
-
-
-// export const updateCommunity = useMock ? mock.updateCommunity : real.updateCommunity;
-// export const deleteCommunity = useMock ? mock.deleteCommunity : real.deleteCommunity;
-
-// export const createComment = useMock ? mock.createComment : real.createComment;
-
-// export const addLikePost = useMock ? mock.addLikePost : real.addLikePost;
-// export const deleteLikePost = useMock ? mock.deleteLikePost : real.deleteLikePost;
-
-// export const getOG = useMock ? mock.getOG : real.getOG;
-// export const openGraph = useMock ? mock.openGraph : real.openGraph;

--- a/src/app/clientPage.tsx
+++ b/src/app/clientPage.tsx
@@ -6,6 +6,7 @@ import ArrowRightIcon from "@/components/icons/ArrowRightIcon";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { useSearchStore } from "@/store/searchStore";
 import InstructorProfile from "./_components/InstructorProfile";
 import LessonChip from "@/components/ui/Chip";
 import { LuEye } from "react-icons/lu";
@@ -17,11 +18,13 @@ import { CATEGORYNAME_TO_LABEL, CategoryName } from "@/constants/categories";
 
 // export default function Home({content}: {content: string}) {
 export default function HomeClient({ home }: { home: HomeProps }) {
-  // const router = useRouter();
+  const router = useRouter();
   // useEffect(() => {
   //   router.replace("/lessons");
   // }, [router]);
   const [maxLength, setMaxLength] = useState(10);
+  const [homeKeyword, setHomeKeyword] = useState("");
+  const { setKeyword } = useSearchStore();
 
   const popularLessons = home.topViewLessonList;
   const NewLessons = home.newLessonList;
@@ -61,21 +64,31 @@ export default function HomeClient({ home }: { home: HomeProps }) {
       {/* 검색창 */}
       <section className="flex flex-col">
         <div className="flex items-center gap-2 pt-6 px-4 pb-5">
-          {/* <h2 className="text-heading_2 text-gray-900">수영장</h2> */}
-          {/* <p className="text-body_lb text-gray-500">{pools.length}</p> */}
-          <Link href="/search" className="relative w-full">
+          <form
+            className="relative w-full"
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (!homeKeyword.trim()) return;
+              setKeyword(homeKeyword.trim());
+              router.push("/search");
+            }}
+          >
             <div className="relative w-full">
-              <CiSearch
-                className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-500"
-                size={20}
-              />
               <input
                 type="text"
+                value={homeKeyword}
+                onChange={(e) => setHomeKeyword(e.target.value)}
                 placeholder="클래스명, 수영장, 커뮤니티 글을 검색해보세요"
-                className="w-full pl-10 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none"
-              ></input>
+                className="w-full pl-4 pr-10 py-2 border border-gray-300 rounded-lg focus:outline-none"
+              />
+              <button
+                type="submit"
+                className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-500 hover:text-gray-900"
+              >
+                <CiSearch size={20} />
+              </button>
             </div>
-          </Link>
+          </form>
         </div>
       </section>
 

--- a/src/app/community/posts/[id]/clientPage.tsx
+++ b/src/app/community/posts/[id]/clientPage.tsx
@@ -13,20 +13,15 @@ import { useRouter } from "next/navigation";
 import { CommunityProps } from "@/types/community";
 import { CATEGORYNAME_TO_LABEL } from "@/constants/categories";
 import CustomModal from "@/app/_components/CustomModal";
-import {
-  addLikePost,
-  createComment,
-  deleteCommunity,
-  deleteLikePost,
-} from "@/api/server/community/real";
-import { getPost } from "@/lib/community/communityRepo.client";
+import { getPost, deletePost, toggleLike, addComment } from "@/lib/community/communityRepo.client";
+import toast from "react-hot-toast";
 import { formatKST } from "@/utils";
 import DetailPagePhotoSlider from "@/app/_components/PhotoSlider";
 import CommentList from "../../_components/CommentList";
 
 export default function ClientCommunity({ postId }: { postId: number }) {
   const [community, setCommunity] = useState<CommunityProps | null>(null);
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useState(true);
   const [comment, setComment] = useState("");
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -102,61 +97,39 @@ export default function ClientCommunity({ postId }: { postId: number }) {
   };
 
   const handleDelete = async () => {
-    const isDeleted = await deleteCommunity(postId + "", "1");
-
-    if (isDeleted) {
-      await router.replace("/community/posts/list?category=none&page=0");
-      alert("게시글이 삭제되었습니다.");
-    } else {
-      alert("게시글 삭제에 실패했습니다.");
+    try {
+      await deletePost(postId);
+      router.replace("/community/posts/list?category=none");
+      toast.success("게시글이 삭제되었습니다.");
+    } catch (error) {
+      console.error("게시글 삭제 실패:", error);
+      toast.error("게시글 삭제에 실패했습니다.");
     }
   };
 
   const handleLike = async () => {
-    if(!community) return;
-    
+    if (!community) return;
+
     try {
-      setChangeLiked((prev) => !prev);
-      setChangeLikesCnt((prev) => (changeLiked ? prev - 1 : prev + 1));
-
-      const response = changeLiked
-        ? await deleteLikePost(postId + "", "1") //좋아요가 되어있으면
-        : await addLikePost(postId + "", "1"); //좋아요가 안되어있으면
-
-      if (!response || !response.success || response.data === null) {
-        throw new Error(response?.message || "서버 응답 오류");
-      }
-
-      setChangeLiked(response.data.isLiked);
-      setChangeLikesCnt(response.data.likeCnt);
+      const { isLiked, likesCnt } = await toggleLike(postId);
+      setChangeLiked(isLiked);
+      setChangeLikesCnt(likesCnt);
     } catch (error) {
-      console.error("좋아요 처리 오류! 기존으로 돌아갑니다:::", error);
-
-      // 상태 롤백
-      setChangeLiked((prev) => !prev);
-      setChangeLikesCnt((prev) => (changeLiked ? prev + 1 : prev - 1));
+      console.error("좋아요 처리 오류:", error);
     }
   };
 
   const handleCommentSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const formData = new FormData();
-    formData.append("postId", String(postId));
-    formData.append("content", comment);
-    formData.append("memberId", "1");
+    if (!comment.trim()) return;
 
     try {
-      const result = await createComment(formData);
-
-      // {
-      //   "content": "9482308953개요",
-      //   "postId": 13,
-      //   "memberId": 1
-      // }
-
-      setComment(""); //댓글필드 초기화
+      const updatedComments = await addComment(postId, comment);
+      setCommunity((prev) => prev ? { ...prev, commentList: updatedComments, cmntCnt: updatedComments.length } : prev);
+      setComment("");
     } catch (error) {
-      console.error("댓글 등록 실패!", error);
+      console.error("댓글 등록 실패:", error);
+      toast.error("댓글 등록에 실패했습니다.");
     }
   };
 
@@ -164,10 +137,10 @@ export default function ClientCommunity({ postId }: { postId: number }) {
   const handleCopyLink = async () => {
     try {
       await navigator.clipboard.writeText(window.location.href);
-      alert("링크가 복사되었습니다!");
+      toast.success("링크가 복사되었습니다!");
     } catch (error) {
-      alert("링크 복사에 실패하였습니다!");
-      console.error("클립보드 복사 실패!::", error);
+      console.error("클립보드 복사 실패:", error);
+      toast.error("링크 복사에 실패하였습니다.");
     }
   };
 

--- a/src/lib/community/communityRepo.client.ts
+++ b/src/lib/community/communityRepo.client.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { CommunitiesProps, CommunityProps } from "@/types/community";
+import { CommunitiesProps, CommunityProps, CommentProps } from "@/types/community";
 import { buildCommunityDetail } from "./mockCommunityDetail";
 import { CATEGORY_NAMES, CategoryName, KEY_TO_CATEGORYNAME } from "@/constants/categories";
 
@@ -118,6 +118,45 @@ export async function updatePost(postId: number, updates: Partial<CommunityProps
   if (idx === -1) throw new Error("Post not found");
   posts[idx] = { ...posts[idx], ...updates, updatedAt: new Date().toISOString() };
   localStorage.setItem(STORAGE_KEY, JSON.stringify(posts));
+}
+
+export async function deletePost(postId: number): Promise<void> {
+  const posts = await listPosts();
+  const filtered = posts.filter((p) => Number(p.postId) !== postId);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(filtered));
+}
+
+export async function toggleLike(postId: number): Promise<{ isLiked: boolean; likesCnt: number }> {
+  const posts = await listPosts();
+  const idx = posts.findIndex((p) => Number(p.postId) === postId);
+  if (idx === -1) throw new Error("Post not found");
+  const post = posts[idx];
+  const newIsLiked = !post.isLiked;
+  const newLikesCnt = newIsLiked ? post.likesCnt + 1 : post.likesCnt - 1;
+  posts[idx] = { ...post, isLiked: newIsLiked, likesCnt: newLikesCnt };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(posts));
+  return { isLiked: newIsLiked, likesCnt: newLikesCnt };
+}
+
+export async function addComment(postId: number, content: string): Promise<CommentProps[]> {
+  const posts = await listPosts();
+  const idx = posts.findIndex((p) => Number(p.postId) === postId);
+  if (idx === -1) throw new Error("Post not found");
+  const newComment: CommentProps = {
+    cmntId: Date.now(),
+    content,
+    writer: "나",
+    writerProfile: null,
+    groupName: 0,
+    orderNumber: 0,
+    cmntClass: 0,
+    likeCnt: 0,
+    createdAt: new Date().toISOString(),
+  };
+  const updated = [...(posts[idx].commentList ?? []), newComment];
+  posts[idx] = { ...posts[idx], commentList: updated, cmntCnt: updated.length };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(posts));
+  return updated;
 }
 
 export async function listPage(params: {


### PR DESCRIPTION
**Mock 상호작용 연결 및 검색 UX 개선**
-

<h3>[P6의 내용]</h3>
<img width="847" height="206" alt="image" src="https://github.com/user-attachments/assets/072a8a59-dccc-4d4f-a18a-6fad5527f0c7" />


<br/>

<h3>[배경]</h3>

- 백엔드 이탈로 인해 detail 페이지의 좋아요/댓글/게시글 삭제가 real.ts를 직접 호출하여 mock 모드에서 항상 실패하는 상태  

<h3>[문제]</h3>

1. 좋아요 / 댓글 / 게시글 삭제 — real.ts 직접 호출로 mock 모드에서 동작 불가
2. 삭제/복사 성공·실패 시 alert() 사용 — UX 일관성 없음
3. 댓글 작성 후 화면 미반영 — setCommunity 업데이트 없음                                                                            
4. index.ts에 mock 미정의 참조 주석 코드 잔류                                                                                       
5. 홈 검색 input 동작 없음 — 입력해도 아무 반응 없음                                                                                
6. detail 페이지 댓글 작성 시 로그인 버튼을 눌러야만 입력창이 표시됨  


<h3>[작업 내용]</h3>
<b>1. communityRepo.client.ts — deletePost / toggleLike / addComment 신규 추가</b>

<b>2. clientPage.tsx — real.ts import 제거, communityRepo 함수로 교체</b>

- handleDelete: deletePost + toast                                                                                                
- handleLike: toggleLike 단일 호출로 단순화                                                                                       
- handleCommentSubmit: addComment + setCommunity로 댓글 즉시 반영                                                                 
- handleCopyLink: alert → toast

<b>3. index.ts — 미사용 주석 dead code 전부 제거</b>                                                      
<b>4. clientPage.tsx</b>
-  isLoggedIn 초기값 true로 변경 (mock 모드 항상 댓글 가능)

<b>5. clientPage.tsx(홈)</b>
- 검색 input에 키워드 입력 후 엔터 또는 돋보기 버튼 클릭 시 Zustand store에 keyword 저장 후 /search로 이동                                                                             
          
<h3>[결과 및 개선]</h3>

- 좋아요 / 댓글 / 삭제 mock 모드에서 정상 동작
- 댓글 작성 후 목록 즉시 반영
- 홈 검색 input → search 페이지 이동 + 결과 바로 표시                                                                               
- alert 전부 제거, toast로 통일 

<h3>[검증]</h3>

- 게시글 삭제 → list 이동 확인
- 좋아요 → 숫자 즉시 반영 확인
- 댓글 작성 → 목록 즉시 표시 확인                                                                                                   
- 홈 검색 input → /search 이동 + 결과 표시 확인                                                                                     
- 빌드 통과 확인

<h3>[할 일]</h3>

- [x] 좋아요 / 댓글 / 게시글 수정·삭제 mock 연결 (P5 선택 작업)
- [ ] 데모 GIF 촬영 후 README에 추가
- [ ] 답글(대댓글) 기능 - 추후 기획 필요
