### PR TITLE
Feat: a11y/에러 바운더리/로딩 UI 추가

### DIFF
--- a/src/app/_components/PhotoSlider.tsx
+++ b/src/app/_components/PhotoSlider.tsx
@@ -140,6 +140,7 @@ const DetailPagePhotoSlider = ({ imageUrls, alt, sliderType = "community" }: Pro
         {/* 왼쪽 화살표 */}
         {!isTouchDevice && isHover && (
           <button
+            aria-label="이전 이미지"
             className="absolute left-2 top-1/2 transform -translate-y-1/2 bg-black bg-opacity-50 text-white p-2 rounded-full"
             onClick={handlePrev}
           >
@@ -150,6 +151,7 @@ const DetailPagePhotoSlider = ({ imageUrls, alt, sliderType = "community" }: Pro
         {/* 오른쪽 화살표 */}
         {!isTouchDevice && isHover && (
           <button
+            aria-label="다음 이미지"
             className="absolute right-2 top-1/2 transform -translate-y-1/2 bg-black bg-opacity-50 text-white p-2 rounded-full"
             onClick={handleNext}
           >

--- a/src/app/_components/PhotoViewerModal.tsx
+++ b/src/app/_components/PhotoViewerModal.tsx
@@ -37,6 +37,7 @@ const PhotoViewerModal = ({ isOpen, onClose, urls, current }: Props) => {
         >
           <div className="flex-none w-full flex justify-end">
             <button
+              aria-label="닫기"
               className="flex items-center justify-center p-3"
               onClick={onClose}
             >
@@ -120,6 +121,7 @@ const ImageSlider = ({ urls, currentIndex, setCurrentIndex }: { urls: string[], 
         {/* 왼쪽 버튼 */}
           {!isTouchDevice && isHover && (
             <button
+              aria-label="이전 이미지"
               className="absolute left-2 top-1/2 transform -translate-y-1/2 bg-black bg-opacity-50 text-white p-2 rounded-full"
               onClick={handlePrev}>
               <FaChevronLeft />
@@ -129,6 +131,7 @@ const ImageSlider = ({ urls, currentIndex, setCurrentIndex }: { urls: string[], 
         {/* 오른쪽 버튼 */}
           {!isTouchDevice && isHover && (
             <button
+              aria-label="다음 이미지"
               className="absolute right-2 top-1/2 transform -translate-y-1/2 bg-black bg-opacity-50 text-white p-2 rounded-full"
               onClick={handleNext}
             >

--- a/src/app/clientPage.tsx
+++ b/src/app/clientPage.tsx
@@ -48,6 +48,7 @@ export default function HomeClient({ home }: { home: HomeProps }) {
               />
               <button
                 type="submit"
+                aria-label="검색"
                 className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-500 hover:text-gray-900"
               >
                 <CiSearch size={20} />

--- a/src/app/community/posts/[id]/clientPage.tsx
+++ b/src/app/community/posts/[id]/clientPage.tsx
@@ -149,11 +149,11 @@ export default function ClientCommunity({ postId }: { postId: number }) {
     <div className="flex flex-col pb-10 relative h-full">
       {/* 상단Nav */}
       <div className="flex items-center justify-between py-1 px-1">
-        <button type="button" className="flex p-3" onClick={() => router.back()}>
+        <button type="button" aria-label="뒤로 가기" className="flex p-3" onClick={() => router.back()}>
           <ArrowLeftIcon className="w-6 h-6 text-gray-900" />
         </button>
 
-        <button type="button" className="flex p-3" onClick={handleMenuToggle}>
+        <button type="button" aria-label="게시글 메뉴 열기" className="flex p-3" onClick={handleMenuToggle}>
           <VscKebabVertical className="mt-1 w-6 h-6 text-gray-900" />
         </button>
       </div>
@@ -241,6 +241,7 @@ export default function ClientCommunity({ postId }: { postId: number }) {
 
       <div className="flex justify-center items-center gap-4">
         <button
+          aria-label={changeLiked ? "좋아요 취소" : "좋아요"}
           className="flex flex-row justify-center items-center gap-1 flex-1"
           onClick={handleLike}
         >
@@ -251,10 +252,9 @@ export default function ClientCommunity({ postId }: { postId: number }) {
           )}
           <span className="text-gray-700">{changeLikesCnt}</span>
         </button>
-        <button className="flex justify-center items-center gap-1 flex-1">
+        <button aria-label="링크 복사" className="flex justify-center items-center gap-1 flex-1" onClick={handleCopyLink}>
           <RiShare2Line
             className="w-5 h-5 text-gray-700"
-            onClick={handleCopyLink}
           />
           <p className="text-gray-500"></p>
         </button>

--- a/src/app/community/posts/[id]/clientPage.tsx
+++ b/src/app/community/posts/[id]/clientPage.tsx
@@ -141,9 +141,7 @@ export default function ClientCommunity({ postId }: { postId: number }) {
     }
   };
 
-  if (!community) {
-    return <div className="flex justify-center py-20 text-gray-400 text-sm">로딩중...</div>;
-  }
+  if (!community) return null;
 
   return (
     <div className="flex flex-col pb-10 relative h-full">

--- a/src/app/community/posts/[id]/edit/page.tsx
+++ b/src/app/community/posts/[id]/edit/page.tsx
@@ -353,6 +353,7 @@ useEffect(() => {
                 </span>
                 <button
                   type="button"
+                  aria-label={`기존 이미지 ${index + 1} 삭제`}
                   onClick={() => handleExistImageDelete(image.imageUrl)}
                   className="absolute w-5 h-5 top-1 right-1 bg-gray-600 text-white font-semibold text-xs flex justify-center rounded-full"
                 >
@@ -372,6 +373,7 @@ useEffect(() => {
 
                 <button
                   type="button"
+                  aria-label={`새 이미지 ${index + 1} 삭제`}
                   onClick={() => handleNewImageDelete(index)}
                   className="absolute w-5 h-5 top-1 right-1 bg-gray-600 text-white font-semibold text-xs flex justify-center rounded-full"
                 >

--- a/src/app/community/posts/[id]/error.tsx
+++ b/src/app/community/posts/[id]/error.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export default function PostError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  const router = useRouter();
+
+  return (
+    <div className="flex flex-col items-center justify-center h-screen gap-4 text-gray-700">
+      <p className="text-lg font-semibold">게시글을 불러올 수 없습니다.</p>
+      <p className="text-sm text-gray-500">삭제되었거나 존재하지 않는 게시글입니다.</p>
+      <div className="flex gap-3">
+        <button
+          onClick={() => reset()}
+          className="px-4 py-2 text-sm bg-blue-900 text-white rounded-lg"
+        >
+          다시 시도
+        </button>
+        <button
+          onClick={() => router.back()}
+          className="px-4 py-2 text-sm bg-gray-100 text-gray-700 rounded-lg"
+        >
+          뒤로 가기
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/community/posts/[id]/loading.tsx
+++ b/src/app/community/posts/[id]/loading.tsx
@@ -1,0 +1,7 @@
+export default function PostLoading() {
+  return (
+    <div className="flex justify-center items-center h-screen text-sm text-gray-400">
+      로딩중...
+    </div>
+  );
+}

--- a/src/app/community/posts/page.tsx
+++ b/src/app/community/posts/page.tsx
@@ -241,6 +241,7 @@ export default function CreatePost() {
                 />
                 <button
                   type="button"
+                  aria-label={`이미지 ${index + 1} 삭제`}
                   onClick={() =>
                     setImages((prev) => prev.filter((_, i) => i !== index))
                   }

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  const router = useRouter();
+
+  return (
+    <div className="flex flex-col items-center justify-center h-screen gap-4 text-gray-700">
+      <p className="text-lg font-semibold">문제가 발생했습니다.</p>
+      <p className="text-sm text-gray-500">잠시 후 다시 시도해주세요.</p>
+      <div className="flex gap-3">
+        <button
+          onClick={() => reset()}
+          className="px-4 py-2 text-sm bg-blue-900 text-white rounded-lg"
+        >
+          다시 시도
+        </button>
+        <button
+          onClick={() => router.back()}
+          className="px-4 py-2 text-sm bg-gray-100 text-gray-700 rounded-lg"
+        >
+          뒤로 가기
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/lessons/[id]/error.tsx
+++ b/src/app/lessons/[id]/error.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export default function LessonError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  const router = useRouter();
+
+  return (
+    <div className="flex flex-col items-center justify-center h-screen gap-4 text-gray-700">
+      <p className="text-lg font-semibold">수업 정보를 불러올 수 없습니다.</p>
+      <p className="text-sm text-gray-500">삭제되었거나 존재하지 않는 수업입니다.</p>
+      <div className="flex gap-3">
+        <button
+          onClick={() => reset()}
+          className="px-4 py-2 text-sm bg-blue-900 text-white rounded-lg"
+        >
+          다시 시도
+        </button>
+        <button
+          onClick={() => router.back()}
+          className="px-4 py-2 text-sm bg-gray-100 text-gray-700 rounded-lg"
+        >
+          뒤로 가기
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/lessons/[id]/loading.tsx
+++ b/src/app/lessons/[id]/loading.tsx
@@ -1,0 +1,7 @@
+export default function LessonLoading() {
+  return (
+    <div className="flex justify-center items-center h-screen text-sm text-gray-400">
+      로딩중...
+    </div>
+  );
+}

--- a/src/app/mypage/profile/_components/UserProfileImage.tsx
+++ b/src/app/mypage/profile/_components/UserProfileImage.tsx
@@ -31,7 +31,7 @@ const UserProfileImage = ({
   return (
     <div className="flex-none flex relative">
       <Image
-        alt="profileImage"
+        alt="프로필 이미지"
         src={imageUrl}
         width={96}
         height={96}
@@ -39,6 +39,7 @@ const UserProfileImage = ({
         priority
       />
       <button
+        aria-label="프로필 이미지 변경"
         className="flex p-1 absolute bottom-0 right-0 bg-gray-400 rounded-full"
         onClick={openFileInput}
         type="button"

--- a/src/app/pools/[id]/error.tsx
+++ b/src/app/pools/[id]/error.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export default function PoolError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  const router = useRouter();
+
+  return (
+    <div className="flex flex-col items-center justify-center h-screen gap-4 text-gray-700">
+      <p className="text-lg font-semibold">수영장 정보를 불러올 수 없습니다.</p>
+      <p className="text-sm text-gray-500">삭제되었거나 존재하지 않는 수영장입니다.</p>
+      <div className="flex gap-3">
+        <button
+          onClick={() => reset()}
+          className="px-4 py-2 text-sm bg-blue-900 text-white rounded-lg"
+        >
+          다시 시도
+        </button>
+        <button
+          onClick={() => router.back()}
+          className="px-4 py-2 text-sm bg-gray-100 text-gray-700 rounded-lg"
+        >
+          뒤로 가기
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/pools/[id]/loading.tsx
+++ b/src/app/pools/[id]/loading.tsx
@@ -1,0 +1,7 @@
+export default function PoolLoading() {
+  return (
+    <div className="flex justify-center items-center h-screen text-sm text-gray-400">
+      로딩중...
+    </div>
+  );
+}


### PR DESCRIPTION
**a11y/에러 바운더리/로딩 UI 추가**
-

<h3>[배경]</h3>

- 접근성 대응 전무 및 에러/로딩 상황에 대한 UI 처리 부재

<h3>[문제]</h3>

1. 아이콘 버튼 전체에 aria-label 없음 → 스크린리더 읽기 불가
2. 에러 발생 시 흰 화면 또는 Next.js 기본 에러 페이지 노출
3. 서버 데이터 fetch 중 빈 화면 노출

<h3>[작업 내용]</h3>

<b>1. aria-label 추가</b>
- 뒤로가기, 케밥메뉴, 좋아요, 공유, 검색, 이미지 삭제, 슬라이더 버튼 등 전체
- alt="profileImage" → "프로필 이미지" 교체

<b>2. error.tsx 추가</b>
- 전역 + detail 3개 (게시글/수업/수영장) 세그먼트별 에러 바운더리
- "다시 시도" / "뒤로 가기" 버튼 포함, 디자인 기존 CustomModal과 통일

<b>3. loading.tsx 추가</b>
- detail 3개 세그먼트 Suspense 폴백
- clientPage.tsx 기존 로딩중... 텍스트 제거

<h3>[결과 및 개선]</h3>

- 스크린리더로 모든 버튼 탐색 가능
- 에러/로딩 상황에 일관된 UI 제공

<h3>[검증]</h3>

- 임시 throw / setTimeout 삽입 후 error.tsx / loading.tsx 정상 렌더링 확인

<h3>[할 일]</h3>

- [ ] 데모 GIF 촬영 후 README에 추가
