### PR TITLE
Docs: README에 Vitest 기술 스택 및 calcDDay 타임존 트러블슈팅 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ next-env.d.ts
 build.sh
 claude.md
 /Claude-Work
+.claude/

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 | Validation | Zod | API 경계에서 런타임 타입 검증 및 transform으로 안전한 데이터 처리 |
 | 상태 관리 | Zustand | 검색 상태를 여러 컴포넌트에서 공유하고 props drilling 없이 접근 |
 | 인증 | Kakao OAuth | 소셜 로그인 UX 제공 |
+| 테스트 | Vitest | 유틸 함수(formatKST, calcDDay) 단위 테스트 작성 |
 
 ---
 
@@ -152,6 +153,29 @@ initMap();
 
 스크립트 로드 후에도 지도 타일이 표시되지 않아 카카오 개발자 콘솔을 확인한 결과, **카카오맵 API가 비활성화** 상태였습니다. API 활성화 및 플랫폼 도메인 등록으로 최종 해결했습니다.
 
+### calcDDay 타임존 버그 — D-Day 계산이 하루 밀리는 문제
+
+수업 목록에서 D-Day 배지가 KST 기준으로 하루씩 밀려 표시되는 문제가 발생했습니다.
+
+**원인 — `new Date()` UTC 파싱**
+
+```ts
+// 수정 전: "2025.03.01" → JavaScript가 UTC 기준으로 파싱
+const date = new Date("2025.03.01"); // UTC 00:00 → KST 09:00, 날짜가 달라짐
+```
+
+날짜 문자열을 `new Date(string)` 에 직접 넘기면 브라우저/Node 환경에 따라 UTC로 해석됩니다. KST(UTC+9)에서는 `2025-03-01T00:00:00Z`가 `2025-03-01 09:00 KST`가 되어 날짜 비교가 어긋납니다.
+
+**해결 — 로컬 시간 파싱**
+
+```ts
+// 수정 후: 연/월/일을 직접 분리해 로컬 시간으로 생성
+const [y, m, d] = "2025.03.01".split(".").map(Number);
+const date = new Date(y, m - 1, d); // 로컬 기준 2025-03-01 00:00
+```
+
+`new Date(year, month, day)` 생성자는 항상 로컬 타임존을 사용합니다. 단위 테스트(Vitest)로 KST 경계값 케이스를 검증해 재발을 방지했습니다.
+
 ---
 
 ## 📁 폴더 구조
@@ -176,6 +200,8 @@ src/
 ```bash
 npm install
 npm run dev
+npm run test                                        # 단위 테스트 전체 실행
+npx vitest run src/utils/formatKST.test.ts          # 단일 테스트 파일 실행
 ```
 
 **환경변수 설정** (`.env.local`):


### PR DESCRIPTION
**README에 Vitest 기술 스택 및 calcDDay 타임존 트러블슈팅 추가**
-

<h3>[배경]</h3>

-  Vitest 단위 테스트 작성 및 calcDDay 타임존 버그 수정 작업이 완료되었으나 README에 반영되지 않음

<h3>[작업 내용]</h3>

<b>1. 기술 스택 표에 Vitest 추가</b>
- 유틸 함수(formatKST, calcDDay) 단위 테스트 작성 내용 명시
                                                                                                                                                                                                                                                                              
<b>2. 로컬 실행 섹션에 테스트 명령어 추가</b>
- npm run test 및 단일 파일 실행 명령어 추가

<b>3. 트러블슈팅 섹션에 calcDDay 타임존 버그 추가</b>
- new Date("YYYY.MM.DD") UTC 파싱으로 KST 기준 D-Day 계산이 하루 밀리는 문제
- new Date(y, m-1, d) 로컬 파싱으로 해결

<h3>[결과 및 개선]</h3>

- 테스트 작성 여부가 README에서 확인 가능
- 타임존 이슈 해결 과정이 트러블슈팅 섹션에 문서화됨

<h3>[검증]</h3>

- README 내용 육안 확인

<h3>[할 일]</h3>

- [ ] 데모 GIF 촬영 후 README에 추가