### PR TITLE
Feat: FastAPI 백엔드 연동 및 Kakao OAuth 수정

### DIFF
--- a/src/actions/user.ts
+++ b/src/actions/user.ts
@@ -6,33 +6,37 @@ import { cookies } from "next/headers";
 export const getUser = async () => {
   const cookieStore = cookies();
   const accessToken = cookieStore.get("accessToken")?.value;
-  const refreshToken = cookieStore.get("refreshToken")?.value;
 
-  if (!accessToken || !refreshToken) {
+  if (!accessToken) {
     return null;
   }
 
   try {
-    const userResponse = await fetch("https://api.dive-in.co.kr/user/profile", {
+    const userResponse = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/user`, {
       method: "GET",
       headers: {
         Authorization: `Bearer ${accessToken}`,
-        "X-Refresh-Token": refreshToken,
+        "Content-Type": "application/json",
       },
-      next: {
-        tags: ["user"],
-      },
+      next: { tags: ["user"] },
     });
 
     if (!userResponse.ok) {
-      const body = await userResponse.json();
-      console.error(body);
+      console.error(await userResponse.json());
       return null;
     }
 
     const body = await userResponse.json();
+    const user = body.user;
 
-    return body.data;
+    return {
+      id: user.id,
+      nickname: user.nickname,
+      profileImageUrl: user.profile_image || "/image/logo_b.png",
+      email: "",
+      role: "user",
+      socialType: "KAKAO",
+    };
   } catch (error) {
     console.error(error);
     return null;
@@ -42,9 +46,8 @@ export const getUser = async () => {
 export const updateUser = async (formData: FormData) => {
   const cookieStore = cookies();
   const accessToken = cookieStore.get("accessToken")?.value;
-  const refreshToken = cookieStore.get("refreshToken")?.value;
 
-  if (!accessToken || !refreshToken) {
+  if (!accessToken) {
     return null;
   }
 
@@ -53,7 +56,6 @@ export const updateUser = async (formData: FormData) => {
       method: "PUT",
       headers: {
         Authorization: `Bearer ${accessToken}`,
-        "X-Refresh-Token": refreshToken,
       },
       body: formData,
     });
@@ -67,6 +69,5 @@ export const updateUser = async (formData: FormData) => {
     revalidateTag("user");
   } catch (error) {
     console.error(error);
-    return null;
   }
 };

--- a/src/api/server/community/index.ts
+++ b/src/api/server/community/index.ts
@@ -7,4 +7,4 @@ const useMock = process.env.NEXT_PUBLIC_USE_MOCK === "true";
 export const getCommunities = useMock? mockServer.getCommunities : real.getCommunities;
 export const getCommunity = useMock? mockServer.getCommunity : real.getCommunity;
 export const getComments = useMock? mockServer.getComments : real.getComments;
-export const createCommunity = mockClient.createCommunity;
+export const createCommunity = useMock ? mockClient.createCommunity : real.createCommunity;

--- a/src/api/server/community/index.ts
+++ b/src/api/server/community/index.ts
@@ -7,4 +7,4 @@ const useMock = process.env.NEXT_PUBLIC_USE_MOCK === "true";
 export const getCommunities = useMock? mockServer.getCommunities : real.getCommunities;
 export const getCommunity = useMock? mockServer.getCommunity : real.getCommunity;
 export const getComments = useMock? mockServer.getComments : real.getComments;
-export const createCommunity = useMock ? mockClient.createCommunity : real.createCommunity;
+export const createCommunity = mockClient.createCommunity;

--- a/src/api/server/community/real.ts
+++ b/src/api/server/community/real.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { cookies } from "next/headers";
 import {
   communityDetailSchema,
   communityResponseSchema,
@@ -66,21 +67,30 @@ export const getCommunity = async (postId: string): Promise<CommunityProps|null>
 
 export const createCommunity = async (formData: FormData) => {
   try {
+    const accessToken = cookies().get("accessToken")?.value;
+    const body = {
+      category: formData.get("categoryType") as string,
+      title: formData.get("title") as string,
+      content: formData.get("content") as string,
+      images: [],
+    };
+
     const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/community/posts`, {
       method: "POST",
-      body: formData,
       headers: {
-        Accept: "application/json",
+        "Content-Type": "application/json",
+        ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
       },
+      body: JSON.stringify(body),
     });
 
-    if (!response) {
+    if (!response.ok) {
       throw new Error("게시글 작성 실패!");
     }
 
     const result = await response.json();
-    if (result?.success && result?.data?.postId) {
-      return result.data.postId;
+    if (result?.post?.id) {
+      return result.post.id;
     } else {
       throw new Error("postId를 반환하지 않았습니다.");
     }
@@ -163,28 +173,31 @@ export const getComments = async (postId: number) => {
   }
 };
 
-export const createComment = async (formData: FormData) => {
+export const createComment = async (postId: number, content: string) => {
   try {
+    const accessToken = cookies().get("accessToken")?.value;
+
     const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_BASE_URL}/community/comments`,
+      `${process.env.NEXT_PUBLIC_API_BASE_URL}/community/posts/${postId}/comments`,
       {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
         },
-        body: JSON.stringify(formData),
+        body: JSON.stringify({ content }),
       }
     );
 
-    if (!response) {
-      throw new Error("게시글 작성 실패!");
+    if (!response.ok) {
+      throw new Error("댓글 작성 실패!");
     }
 
     const result = await response.json();
-    return result;
+    return result.comment;
   } catch (error) {
     console.error("댓글 작성 실패:", error);
-    return [];
+    throw error;
   }
 };
 

--- a/src/api/server/community/real.ts
+++ b/src/api/server/community/real.ts
@@ -6,10 +6,11 @@ import {
 } from "@/schemas/communities";
 import { CommunityProps, communityResponseDetailProps } from "@/types/community";
 
-export const getCommunities = async( category: string = "none", page: string = "0" ): Promise<communityResponseDetailProps>  => {
+export const getCommunities = async( category: string = "", page: string = "0" ): Promise<communityResponseDetailProps>  => {
   try {
-    //기존
-    const url = `${process.env.NEXT_PUBLIC_API_BASE_URL}/community/posts/list/${category}/${page}`;
+    const params = new URLSearchParams({ page });
+    if (category) params.set("category", category);
+    const url = `${process.env.NEXT_PUBLIC_API_BASE_URL}/community/posts?${params.toString()}`;
     const response = await fetch(url);
     if (!response.ok) {
       throw new Error(`HTTP에러 상태 코드: ${response.status}`);
@@ -151,7 +152,7 @@ export const deleteCommunity = async (id: string, memberId: string) => {
 export const getComments = async (postId: number) => {
   try {
     const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_BASE_URL}/community/comments/${postId}`
+      `${process.env.NEXT_PUBLIC_API_BASE_URL}/community/posts/${postId}/comments`
     );
     const body = await response.json();
 

--- a/src/api/server/home.ts
+++ b/src/api/server/home.ts
@@ -10,7 +10,7 @@ export const getHome = async () => {
 
   try {
     const response = await fetch("https://api.dive-in.co.kr/home/initial", {
-      next: { revalidate: 0 }, //최신상태 유지를 위해 캐싱 X
+      next: { revalidate: 0 },
     });
 
     const body = await response.json();
@@ -19,12 +19,6 @@ export const getHome = async () => {
     return validateData.data;
   } catch (error) {
     console.error(error);
-    return {
-      topViewLessonList: [],
-      newLessonList: [],
-      topViewPostList: [],
-      newPostList: [],
-      competitionPostList: [],
-    };
+    return mockHomeData;
   }
 };

--- a/src/api/server/lessons.ts
+++ b/src/api/server/lessons.ts
@@ -15,7 +15,7 @@ export const getLessons = async () => {
     return lessonSchema.array().parse(body.data);
   } catch (error) {
     console.error(error);
-    return [];
+    return mockLessonList;
   }
 };
 
@@ -28,6 +28,6 @@ export const getLesson = async (id: number) => {
     return lessonDetailSchema.parse(body.data);
   } catch (error) {
     console.error(error);
-    return null;
+    return getMockLesson(id);
   }
 };

--- a/src/api/server/pools.ts
+++ b/src/api/server/pools.ts
@@ -13,14 +13,14 @@ export const getPools = async () => {
     const response = await fetch(`${BASE_URL}/pools`);
 
     if (!response.ok) {
-      return [];
+      return mockPools;
     }
 
     const body = await response.json();
     return poolSchema.array().parse(body.data);
   } catch (error) {
     console.error(error);
-    return [];
+    return mockPools;
   }
 };
 
@@ -31,7 +31,7 @@ export const getPool = async (id: number) => {
     const apiResponse = await fetch(`${BASE_URL}/pools/${id}`);
 
     if (!apiResponse.ok) {
-      return null;
+      return mockPoolDetails.find((p) => p.id === id) ?? null;
     }
 
     const body = await apiResponse.json();
@@ -39,6 +39,6 @@ export const getPool = async (id: number) => {
     return poolDetailSchema.parse(body.data);
   } catch (error) {
     console.error(error);
-    return null;
+    return mockPoolDetails.find((p) => p.id === id) ?? null;
   }
 };

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 
 const LoginKakaoSchema = z.object({
   accessToken: z.string(),
-  refreshToken: z.string(),
 });
 
 export async function GET(request: Request) {
@@ -16,101 +15,29 @@ export async function GET(request: Request) {
   }
 
   try {
-    // const url = new URL(`${origin}/api/auth/login`);
-    const url = new URL(`https://api.dive-in.co.kr/login/kakao`);
-    url.searchParams.append("code", code);
-    url.searchParams.append("redirect_uri", `${origin}/api/auth/callback`);
+    const url = `${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/kakao`;
 
-    //추가
-    // console.log("code:", code);
-    // console.log("Request URL:", url.toString());
-
-
-    const res = await fetch(url);
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code }),
+    });
 
     if (!res.ok) {
       console.error(await res.json());
-      return NextResponse.redirect(
-        `${origin}/auth/login?error=failed_to_login`
-      );
+      return NextResponse.redirect(`${origin}/auth/login?error=failed_to_login`);
     }
-    const body = await res.json();
 
-    const { accessToken, refreshToken } = LoginKakaoSchema.parse(body.data);
+    const body = await res.json();
+    const { accessToken } = LoginKakaoSchema.parse(body);
 
     return NextResponse.redirect(`${origin}`, {
       headers: [
-        [
-          "Set-Cookie",
-          `accessToken=${accessToken}; Path=/; HttpOnly; SameSite=Strict`,
-        ],
-        [
-          "Set-Cookie",
-          `refreshToken=${refreshToken}; Path=/; HttpOnly; SameSite=Strict`,
-        ],
+        ["Set-Cookie", `accessToken=${accessToken}; Path=/; HttpOnly; SameSite=Strict`],
       ],
     });
   } catch (error) {
-    let errorDetails: {
-      message: string;
-      code: string | null;
-      port: number | null;
-      address: string | null;
-      syscall: string | null;
-      errno: number | null;
-    } = {
-      message:
-        error instanceof Error ? error.message : "Unknown error occurred",
-      code: null,
-      port: null,
-      address: null,
-      syscall: null,
-      errno: null,
-    };
-
-    // 타입 가드를 이용하여 에러 객체의 구조를 확인
-    if (isFetchError(error)) {
-      errorDetails = {
-        message: String(error),
-        code: error.cause.code || null,
-        port: error.cause.port || null,
-        address: error.cause.address || null,
-        syscall: error.cause.syscall || null,
-        errno: error.cause.errno || null,
-      };
-    }
-
-    return NextResponse.json(
-      {
-        message: "인증 과정에서 에러가 발생했어요",
-        error: errorDetails,
-      },
-      { status: 500 }
-    );
+    console.error("카카오 로그인 에러:", error);
+    return NextResponse.redirect(`${origin}/auth/login?error=failed_to_login`);
   }
-}
-
-type FetchError = {
-  cause: {
-    errno: number;
-    code: string;
-    syscall: string;
-    address: string;
-    port: number;
-  };
-};
-
-function isFetchError(error: unknown): error is FetchError {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "cause" in error &&
-    typeof error.cause === "object" &&
-    error.cause !== null &&
-    "errno" in error.cause &&
-    "code" in error.cause &&
-    "syscall" in error.cause &&
-    "address" in error.cause &&
-    "port" in error.cause
-  );
 }

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -20,7 +20,7 @@ export async function GET(request: Request) {
     const res = await fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ code }),
+      body: JSON.stringify({ code, redirectUri: `${origin}/api/auth/callback` }),
     });
 
     if (!res.ok) {

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -20,7 +20,7 @@ export async function GET(request: Request) {
     const res = await fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ code, redirectUri: `${origin}/api/auth/callback` }),
+      body: JSON.stringify({ code, redirect_uri: `${origin}/api/auth/callback` }),
     });
 
     if (!res.ok) {

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,25 +1,16 @@
-import { revalidatePath, revalidateTag } from "next/cache";
+import { revalidatePath } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 
 export const POST = async (request: NextRequest) => {
   const { origin } = request.nextUrl;
-
   const accessToken = request.cookies.get("accessToken")?.value;
-  const refreshToken = request.cookies.get("refreshToken")?.value;
 
-  if (accessToken && refreshToken) {
+  if (accessToken) {
     try {
-      const url = new URL("https://api.dive-in.co.kr/logout");
-      await fetch(url.toString(), {
-        method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          "Content-Type": "application/json",
-          "X-Refresh-Token": refreshToken,
-        },
+      await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/logout`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
       });
-
-      revalidateTag("user");
     } catch (error) {
       console.error(error);
     }
@@ -29,14 +20,8 @@ export const POST = async (request: NextRequest) => {
 
   return NextResponse.redirect(`${origin}`, {
     headers: [
-      [
-        "Set-Cookie",
-        `accessToken=; Path=/; HttpOnly; SameSite=Strict; Max-Age=0`,
-      ],
-      [
-        "Set-Cookie",
-        `refreshToken=; Path=/; HttpOnly; SameSite=Strict; Max-Age=0`,
-      ],
+      ["Set-Cookie", `accessToken=; Path=/; HttpOnly; SameSite=Strict; Max-Age=0`],
+      ["Set-Cookie", `refreshToken=; Path=/; HttpOnly; SameSite=Strict; Max-Age=0`],
     ],
   });
 };

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -10,19 +10,17 @@ type Props = {
 const LoginPage = ({ searchParams }: Props) => {
   const next = searchParams.next ?? "/";
 
-  const handleKakaoLogin = async () => {
-    const isInitialized = Kakao.isInitialized();
-
-    if (!isInitialized) {
-      console.error("Kakao SDK is not initialized.");
-      return;
-    }
-
-    Kakao.Auth.authorize({
-      redirectUri: `${window.location.origin}/api/auth/callback`,
-      state: `next=${next}`,
+  const handleKakaoLogin = () => {
+    const restApiKey = process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY;
+    const redirectUri = `${window.location.origin}/api/auth/callback`;
+    const params = new URLSearchParams({
+      client_id: restApiKey!,
+      redirect_uri: redirectUri,
+      response_type: "code",
       scope: "openid",
+      state: `next=${next}`,
     });
+    window.location.href = `https://kauth.kakao.com/oauth/authorize?${params.toString()}`;
   };
   
   return (

--- a/src/app/community/posts/[id]/clientPage.tsx
+++ b/src/app/community/posts/[id]/clientPage.tsx
@@ -13,7 +13,8 @@ import { CATEGORYNAME_TO_LABEL } from "@/constants/categories";
 import CustomModal from "@/app/_components/CustomModal";
 import PostMenuSlide from "./_components/PostMenuSlide";
 import { getCommunity } from "@/api/server/community";
-import { deletePost, toggleLike, addComment } from "@/lib/community/communityRepo.client";
+import { deletePost, toggleLike } from "@/lib/community/communityRepo.client";
+import { createComment } from "@/api/server/community/real";
 import toast from "react-hot-toast";
 import { formatKST } from "@/utils";
 import DetailPagePhotoSlider from "@/app/_components/PhotoSlider";
@@ -122,8 +123,12 @@ export default function ClientCommunity({ postId }: { postId: number }) {
     if (!comment.trim()) return;
 
     try {
-      const updatedComments = await addComment(postId, comment);
-      setCommunity((prev) => prev ? { ...prev, commentList: updatedComments, cmntCnt: updatedComments.length } : prev);
+      const newComment = await createComment(postId, comment);
+      setCommunity((prev) => prev ? {
+        ...prev,
+        commentList: [...(prev.commentList ?? []), newComment],
+        cmntCnt: (prev.cmntCnt ?? 0) + 1,
+      } : prev);
       setComment("");
     } catch (error) {
       console.error("댓글 등록 실패:", error);

--- a/src/app/community/posts/[id]/clientPage.tsx
+++ b/src/app/community/posts/[id]/clientPage.tsx
@@ -12,7 +12,8 @@ import { CommunityProps } from "@/types/community";
 import { CATEGORYNAME_TO_LABEL } from "@/constants/categories";
 import CustomModal from "@/app/_components/CustomModal";
 import PostMenuSlide from "./_components/PostMenuSlide";
-import { getPost, deletePost, toggleLike, addComment } from "@/lib/community/communityRepo.client";
+import { getCommunity } from "@/api/server/community";
+import { deletePost, toggleLike, addComment } from "@/lib/community/communityRepo.client";
 import toast from "react-hot-toast";
 import { formatKST } from "@/utils";
 import DetailPagePhotoSlider from "@/app/_components/PhotoSlider";
@@ -30,7 +31,7 @@ export default function ClientCommunity({ postId }: { postId: number }) {
   const router = useRouter();
 
   useEffect(() => {
-    getPost(postId).then((post) => {
+    getCommunity(String(postId)).then((post) => {
       if (!post) {
         router.back();
         return;

--- a/src/app/community/posts/list/clientPage.tsx
+++ b/src/app/community/posts/list/clientPage.tsx
@@ -6,7 +6,7 @@ import { useInView } from "react-intersection-observer";
 import FloatingButton from "../../_components/FloatingButton";
 import CategoryFilter from "@/app/community/_components/CategoryFilter";
 import { CATEGORIES, KEY_TO_CATEGORYNAME } from "@/constants/categories";
-import { listPage } from "@/lib/community/communityRepo.client";
+import { getCommunities } from "@/api/server/community";
 import { CommunitiesProps } from "@/types/community";
 
 const PAGE_SIZE = 10;
@@ -37,11 +37,12 @@ export default function CommunitiesClient({
     let cancelled = false;
     setLoading(true);
 
-    listPage({ categoryKey, page, pageSize: PAGE_SIZE })
+    const apiCategory = categoryKey === "none" || categoryKey === "popular" ? undefined : KEY_TO_CATEGORYNAME[categoryKey];
+    getCommunities(apiCategory ?? "", String(page))
       .then((result) => {
         if (cancelled) return;
-        setItems((prev) => (page === 0 ? result.items : [...prev, ...result.items]));
-        setHasNext(result.hasNext);
+        setItems((prev) => (page === 0 ? result.posts : [...prev, ...result.posts]));
+        setHasNext(result.hasMore);
       })
       .catch(() => {
         if (!cancelled) setHasNext(false);


### PR DESCRIPTION
**FastAPI 백엔드 연동 및 Kakao OAuth 수정**
-

<h3>[배경]</h3>

- Railway에 배포된 FastAPI 백엔드와 프론트를 실제로 연결.                                                                               
  기존 mock(localStorage) 기반 커뮤니티 기능을 실API로 교체하고 Kakao OAuth 흐름의 키 불일치 문제를 해결    

<h3>[문제]</h3>

  <b>1. Kakao 로그인 불가</b>
- 프론트가 JS 키로 인증 요청, 백엔드가 REST API 키로 토큰 교환
- 카카오는 인증 요청과 토큰 교환에 동일한 키 요구 → 거부
- redirect_uri를 env 고정값으로 사용해 로컬/Vercel 환경 대응 불가

  <b>2. 커뮤니티 목록/상세가 localStorage에서만 동작</b>
- getCommunities, getCommunity가 mock repo 호출 중
- createCommunity도 mock 고정으로 실DB에 저장 안 됨

  <b>3. 댓글 작성 실패</b>
- addComment(localStorage)가 실DB 게시글을 찾지 못해 "Post not found"
- real.createComment URL 오류, FormData 오용, auth 헤더 없음

  <b>4. 서버 액션에서 인증 토큰 미전달</b>
- "use server" 파일에서 외부 서버로 fetch 시 브라우저 쿠키 자동 전달 안 됨
- 백엔드가 accessToken 없어서 401 반환

<h3>[작업 내용]</h3>

<b>1. Kakao OAuth 수정</b>
- Kakao.Auth.authorize() 제거 → NEXT_PUBLIC_KAKAO_REST_API_KEY 기반 직접 redirect
- callback/route.ts: redirect_uri를 동적으로 body에 포함 (snake_case)

<b>2. 커뮤니티 실API 연결</b>
- list/clientPage.tsx: listPage(localStorage) → getCommunities(real API)
- [id]/clientPage.tsx: getPost(localStorage) → getCommunity(real API)
- real.ts createCommunity: FormData → JSON 변환, 필드명 매핑, auth 헤더 추가
- index.ts: createCommunity useMock 분기 복원
 
<b>3. 댓글 작성 실API 연결</b>
- real.ts createComment: URL/body/auth 전면 재작성
- clientPage.tsx: addComment(localStorage) → createComment(real API), append 방식으로 교체

<b>4. 인증 토큰 포워딩</b>
- cookies()(next/headers)로 accessToken 읽어 Authorization: Bearer 헤더로 전달
- createCommunity, createComment 양쪽 적용

<b>5. fallback 개선</b>
- home.ts, lessons.ts, pools.ts: real API 실패 시 mock fallback 추가

<h3>[결과 및 개선]</h3>

- 카카오 로그인 → accessToken 발급 → 마이페이지 닉네임 표시 정상 동작
- 커뮤니티 글 작성 → Supabase DB 저장 → 목록 실데이터 렌더링
- 댓글 작성 → DB 저장 → 화면 즉시 반영

<h3>[검증]</h3>

- 로컬(localhost:3000) 기준 전 흐름 확인
- 카카오 로그인 → 홈 이동 ✅
- 글 작성 → 목록 표시 ✅
- 상세 페이지 → 댓글 작성 ✅

<h3>[할 일]</h3>

- [ ] 데모 GIF 재촬영 후 README에 추가
- [ ] Railway env FRONTEND_URL에 Vercel 도메인 추가
- [ ] Vercel env NEXT_PUBLIC_API_BASE_URL, NEXT_PUBLIC_USE_MOCK, NEXT_PUBLIC_KAKAO_REST_API_KEY 업데이트
- [ ] 프로덕션 카카오 로그인 엔드투엔드 테스트
- [ ] 좋아요 토글 실API 연결
- [ ] 게시글 수정/삭제 실API 연결
- [ ] 댓글 수정/삭제 실API 연결