### PR TITLE
Feat: 커뮤니티 글 이미지 Supabase Storage 업로드 연결

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,6 +16,11 @@ const nextConfig = {
       {
         hostname: "dive-in-bucket.kr.object.ncloudstorage.com",
       },
+      {
+        protocol: "https",
+        hostname: "*.supabase.co",
+        pathname: "/storage/v1/object/public/**",
+      },
     ],
   },
 };

--- a/src/api/server/community/real.ts
+++ b/src/api/server/community/real.ts
@@ -66,14 +66,14 @@ export const getCommunity = async (postId: string): Promise<CommunityProps|null>
   }
 };
 
-export const createCommunity = async (formData: FormData) => {
+export const createCommunity = async (formData: FormData, imageUrls: string[] = []) => {
   try {
     const accessToken = cookies().get("accessToken")?.value;
     const body = {
       category: formData.get("categoryType") as string,
       title: formData.get("title") as string,
       content: formData.get("content") as string,
-      images: [],
+      images: imageUrls,
     };
 
     const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/community/posts`, {

--- a/src/app/api/community/upload/route.ts
+++ b/src/app/api/community/upload/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const POST = async (request: NextRequest) => {
+  const accessToken = request.cookies.get("accessToken")?.value;
+  if (!accessToken) {
+    return NextResponse.json({ error: "로그인이 필요합니다" }, { status: 401 });
+  }
+
+  const formData = await request.formData();
+
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/community/upload`,
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${accessToken}` },
+      body: formData,
+    }
+  );
+
+  const data = await response.json().catch(() => null);
+  if (!response.ok) {
+    return NextResponse.json(
+      { error: data?.detail || "업로드 실패" },
+      { status: response.status }
+    );
+  }
+  return NextResponse.json(data);
+};

--- a/src/app/community/posts/[id]/edit/page.tsx
+++ b/src/app/community/posts/[id]/edit/page.tsx
@@ -143,7 +143,7 @@ useEffect(() => {
           const res = await fetch("/api/community/upload", { method: "POST", body: fd });
           const data = await res.json().catch(() => ({}));
           if (!res.ok) throw new Error(data.error || "이미지 업로드 실패");
-          return data.url as string;
+          return data.imageUrls as string; //백엔드랑 변수명 같아야 함
         })
       );
 

--- a/src/app/community/posts/[id]/edit/page.tsx
+++ b/src/app/community/posts/[id]/edit/page.tsx
@@ -129,46 +129,34 @@ useEffect(() => {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    // const formData = new FormData(e.currentTarget);
-    const formData = new FormData();
-    const category = CATEGORIES.find(
-      (category) => category.name === selectedCategory
-    );
+    const category = CATEGORIES.find((c) => c.name === selectedCategory);
     if (!category) {
       toast.error("카테고리를 선택해주세요!");
       return;
     }
 
-    formData.append("memberId", "1");
-    formData.append("categoryType", category.key);
-    formData.append("title", title);
-    formData.append("content", content);
-
-    newImages.forEach((image) => {
-      formData.append("newImages", image);
-    });
-
-    formData.append(
-      "existingImages",
-      JSON.stringify(
-        existImages.map((img) => ({
-          repImage: img.repImage,
-          imageUrl: img.imageUrl,
-        }))
-      )
-    );
-
     try {
+      const newImageUrls = await Promise.all(
+        newImages.map(async (file) => {
+          const fd = new FormData();
+          fd.append("file", file);
+          const res = await fetch("/api/community/upload", { method: "POST", body: fd });
+          const data = await res.json().catch(() => ({}));
+          if (!res.ok) throw new Error(data.error || "이미지 업로드 실패");
+          return data.url as string;
+        })
+      );
+
       await updateCommunity(postId, {
         title,
         content,
-        images: existImages.map((img) => img.imageUrl),
+        images: [...existImages.map((img) => img.imageUrl), ...newImageUrls],
       });
 
       router.replace(`/community/posts/${postId}`);
     } catch (err) {
       console.error(err);
-      toast.error("글 수정에 실패했습니다.");
+      toast.error(err instanceof Error ? err.message : "글 수정에 실패했습니다.");
     }
   };
 
@@ -180,13 +168,17 @@ useEffect(() => {
   const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files) return;
 
-    const selectedFiles = Array.from(e.target.files); //선택파일 배열변환
-    if (existImages.length + newImages.length >= 5) {
+    const selectedFiles = Array.from(e.target.files);
+    const oversized = selectedFiles.find((f) => f.size > 5 * 1024 * 1024);
+    if (oversized) {
+      toast.error("파일 크기는 5MB 이하여야 합니다.");
+      return;
+    }
+    if (existImages.length + newImages.length + selectedFiles.length > 5) {
       toast.error("이미지는 최대 5장까지 업로드 가능합니다.");
       return;
     }
-
-    setNewImages((prev) => [...prev, ...selectedFiles]); //이미지추가
+    setNewImages((prev) => [...prev, ...selectedFiles]);
   };
 
   const handleNewImageDelete = (index: number) => {

--- a/src/app/community/posts/page.tsx
+++ b/src/app/community/posts/page.tsx
@@ -75,17 +75,23 @@ export default function CreatePost() {
     formData.append("categoryType", selectedCategoryKey);
     formData.append("title", title.value.trim());
     formData.append("content", content);
-    formData.append("memberId", "1");
-    images.forEach((image) => {
-      formData.append("images", image);
-    });
 
     try {
-      const postId = await createCommunity(formData);
+      const imageUrls = await Promise.all(
+        images.map(async (file) => {
+          const fd = new FormData();
+          fd.append("file", file);
+          const res = await fetch("/api/community/upload", { method: "POST", body: fd });
+          const data = await res.json().catch(() => ({}));
+          if (!res.ok) throw new Error(data.error || "이미지 업로드 실패");
+          return data.url as string;
+        })
+      );
+      const postId = await createCommunity(formData, imageUrls);
       router.replace(`/community/posts/${postId}`);
     } catch (err) {
       console.error("글 작성 실패", err);
-      toast.error("글 작성에 실패했습니다.");
+      toast.error(err instanceof Error ? err.message : "글 작성에 실패했습니다.");
     } finally {
       isSubmittingRef.current = false;
       setIsLoading(false);
@@ -102,12 +108,17 @@ export default function CreatePost() {
   const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files) return;
 
-    const selectedFiles = Array.from(e.target.files); //선택파일 배열변환
+    const selectedFiles = Array.from(e.target.files);
+    const oversized = selectedFiles.find((f) => f.size > 5 * 1024 * 1024);
+    if (oversized) {
+      toast.error("파일 크기는 5MB 이하여야 합니다.");
+      return;
+    }
     if (images.length + selectedFiles.length > 5) {
       toast.error("이미지는 최대 5장까지 업로드 가능합니다.");
       return;
     }
-    setImages((prev) => [...prev, ...selectedFiles]); //이미지추가
+    setImages((prev) => [...prev, ...selectedFiles]);
   };
 
   const handleImageButtonClick = () => {

--- a/src/app/community/posts/page.tsx
+++ b/src/app/community/posts/page.tsx
@@ -84,7 +84,7 @@ export default function CreatePost() {
           const res = await fetch("/api/community/upload", { method: "POST", body: fd });
           const data = await res.json().catch(() => ({}));
           if (!res.ok) throw new Error(data.error || "이미지 업로드 실패");
-          return data.url as string;
+          return data.imageUrls as string;  //백엔드랑 변수명 같아야 함
         })
       );
       const postId = await createCommunity(formData, imageUrls);


### PR DESCRIPTION
**커뮤니티 글 이미지 Supabase Storage 업로드 연결**
-

<h3>[배경]</h3>

- 글 작성/수정 이미지 선택 UI는 구현돼 있었으나 images: [] 빈 배열을 항상 전송하여 실제 저장이 되지 않던 상태

<h3>[문제]</h3>

1. createCommunity가 images: [] 고정 전송 — 이미지 DB 저장 불가
2. 이미지 파일 크기 검증 없음 — 대용량 파일 제한 없이 진행

<h3>[작업 내용]</h3>

<b>1. /api/community/upload Route Handler 신규 생성</b>
- accessToken 쿠키 읽어 FastAPI로 파일 포워딩, URL 반환

<b>2.  posts/page.tsx — 5MB 크기 검증 추가</b>
- submit 시 Promise.all 병렬 업로드 후 imageUrls 수집 → createCommunity 전달

<b>3. edit/page.tsx — 동일 패턴</b>
- 기존 이미지 URL 유지 + 새 이미지 업로드 병행 → updateCommunity 전달

<b>4. real.ts createCommunity — imageUrls: string[] 인자 추가</b>
- images: [] 고정 → 실제 URL 배열 전달

<b>5. next.config.mjs</b>
- Supabase Storage 도메인 remotePatterns 추가

<h3>[결과 및 개선]</h3>

- 이미지 포함 글 작성 시 Supabase Storage 저장 후 URL이 DB에 기록됨
- 5MB 초과 파일 선택 시 toast.error 처리

<h3>[검증]</h3>

1. 이미지 포함 글 작성 → Storage 버킷에 파일 저장 확인
2. 상세 페이지 이미지 렌더링 확인
3. 글 수정 → 기존 이미지 유지 + 새 이미지 추가 확인
4. 5MB 초과 파일 → toast.error 확인

<h3>[할 일]</h3>

- [ ] 데모 GIF 재촬영 후 README에 추가
- [ ] 프로덕션 E2E 테스트 (Vercel + Railway 배포 후)
- [x] P14: 이미지 업로드 (Supabase Storage)
- [ ] P15: 반응형 웹