### PR TITLE
Feat: 반응형 웹 - TopNav, Grid, Login PC 레이아웃

### DIFF
--- a/src/app/_components/BottomNav.tsx
+++ b/src/app/_components/BottomNav.tsx
@@ -32,7 +32,7 @@ const BottomNav = () => {
   //   setPage(searchParams.get("page"));
   // }, []);
 
-  const isHome = pathname === "/"; //홈일때만 활성화
+  const isHome = pathname === routes.home;
   const isLessons = pathname.startsWith(routes.lessons);
   const isPools = pathname.startsWith(routes.pools);
   const isCommunity =
@@ -47,7 +47,7 @@ const BottomNav = () => {
   }
 
   return (
-    <nav className="flex-none h-14 flex items-center px-4 bg-gray-100 border-t border-slate-200">
+    <nav className="flex-none h-14 flex items-center px-4 bg-gray-100 border-t border-slate-200 xl:hidden">
       <Link
         href={routes.home}
         className={`flex-1 h-full flex flex-col gap-0.5 items-center justify-center ${
@@ -93,7 +93,7 @@ const BottomNav = () => {
         }`}
       >
         <PersonIcon className={`h-6 w-6`} />
-        <span className="text-label_sb">마이</span>
+        <span className="text-label_sb">마이페이지</span>
       </Link>
     </nav>
   );

--- a/src/app/_components/BottomNavWrapper.tsx
+++ b/src/app/_components/BottomNavWrapper.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import {usePathname} from "next/navigation";
-import BottomNav from "./_components/BottomNav";
+import BottomNav from "./BottomNav";
 import { Suspense } from "react";
 
 export default function BottomNavWrapper() {

--- a/src/app/_components/ContentWrapper.tsx
+++ b/src/app/_components/ContentWrapper.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+export default function ContentWrapper({children} : {children: React.ReactNode}) {
+  const pathname = usePathname();
+  const isLogin = pathname.startsWith("/auth/login");
+
+  return (
+    <div className={`w-full flex-1 flex flex-col overflow-hidden ${isLogin? "" : "xl:pt-16"}`}>
+      {children}
+    </div>
+  );
+}

--- a/src/app/_components/OpenGraphLinkReview.tsx
+++ b/src/app/_components/OpenGraphLinkReview.tsx
@@ -46,7 +46,7 @@ export default function OpenGraphPreview({
       {/* 아래에서 슬라이딩 */}
       <div
         ref={containerRef}
-        className={`fixed bottom-0 left-1/2 transform -translate-x-1/2 bg-white p-4 pt-6 pb-10 border-t rounded-t-2xl transition-transform duration-300 ${
+        className={`fixed bottom-0 left-1/2 transform -translate-x-1/2 bg-white px-6 py-6 border-t rounded-t-2xl transition-transform duration-300 ${
           isOpen ? "translate-y-0" : "translate-y-full"
         }`}
         style={{

--- a/src/app/_components/TopNav.tsx
+++ b/src/app/_components/TopNav.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import ChatIcon from "@/components/icons/ChatIcon";
+import PersonIcon from "@/components/icons/PersonIcon";
+import PoolIcon from "@/components/icons/PoolIcon";
+import SwimHatIcon from "@/components/icons/SwimHatIcon";
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname, useSearchParams } from "next/navigation";
+import { GoHome } from "react-icons/go";
+
+const routes = {
+  home: "/",
+  lessons: "/lessons",
+  pools: "/pools",
+  community: "/community/posts/list",
+  mypage: "/mypage",
+  login: "/auth/login",
+};
+
+const TopNav = () => {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const category = searchParams.get("category") || "none";
+  const page = searchParams.get("page") || "0";
+
+  const isHome = pathname === routes.home;
+  const isLessons = pathname.startsWith(routes.lessons);
+  const isPools = pathname.startsWith(routes.pools);
+  const isCommunity =
+    pathname.startsWith(routes.community) &&
+    category === "none" &&
+    page === "0";
+  const isMypage = pathname.startsWith(routes.mypage);
+  const isLogin = pathname.startsWith(routes.login);
+
+  if (isLogin) {
+    return null;
+  }
+
+  return (
+    <nav className="hidden xl:flex xl:fixed items-center xl:left-0 xl:top-0 xl:right-0 xl:h-16 px-8 bg-white z-50 gap-2 relative">
+      <Image
+        alt="로고"
+        src="/image/logo_o.png"
+        width={120}
+        height={28}
+        className="object-contain"
+      />
+
+      <div className="absolute left-1/2 -translate-x-1/2 flex items-center gap-2 text-body_bb">
+        <Link
+          href={routes.home}
+          className={`flex items-center gap-3 px-3 py-2 rounded-lg ${isHome ? "text-gray-900" : "text-gray-500"}`}
+        >
+          <GoHome className={`h-6 w-6`} />
+          <span className="text-body_bb">홈</span>
+        </Link>
+        <Link
+          href={routes.lessons}
+          className={`flex items-center gap-3 px-3 py-2 rounded-lg ${isLessons ? "text-gray-900" : "text-gray-500"}`}
+        >
+          <SwimHatIcon className={`h-6 w-6`} />
+          <span className="text-body_bb">수영클래스</span>
+        </Link>
+        <Link
+          href={routes.pools}
+          className={`flex items-center gap-3 px-3 py-2 rounded-lg ${isPools ? "text-gray-900" : "text-gray-500"}`}
+        >
+          <PoolIcon className={`h-6 w-6`} />
+          <span className="text-body_bb">수영장</span>
+        </Link>
+        <Link
+          href={routes.community}
+          className={`flex items-center gap-3 px-3 py-2 rounded-lg ${isCommunity ? "text-gray-900" : "text-gray-500"}`}
+        >
+          <ChatIcon className={`h-6 w-6`} />
+          <span className="text-body_bb">소통해요</span>
+        </Link>
+        <Link
+          href={routes.mypage}
+          className={`flex items-center gap-3 px-3 py-2 rounded-lg ${isMypage ? "text-gray-900" : "text-gray-500"}`}
+        >
+          <PersonIcon className={`h-6 w-6`} />
+          <span className="text-body_bb">마이페이지</span>
+        </Link>
+      </div>
+    </nav>
+  );
+};
+
+export default TopNav;

--- a/src/app/_components/TopNav.tsx
+++ b/src/app/_components/TopNav.tsx
@@ -48,7 +48,7 @@ const TopNav = () => {
         className="object-contain"
       />
 
-      <div className="absolute left-1/2 -translate-x-1/2 flex items-center gap-2 text-body_bb">
+      <div className="absolute left-1/2 -translate-x-1/2 flex items-center gap-2 text-body_bb overflow-hidden">
         <Link
           href={routes.home}
           className={`flex items-center gap-3 px-3 py-2 rounded-lg ${isHome ? "text-gray-900" : "text-gray-500"}`}

--- a/src/app/_components/TopNav.tsx
+++ b/src/app/_components/TopNav.tsx
@@ -6,7 +6,7 @@ import PoolIcon from "@/components/icons/PoolIcon";
 import SwimHatIcon from "@/components/icons/SwimHatIcon";
 import Image from "next/image";
 import Link from "next/link";
-import { usePathname, useSearchParams } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { GoHome } from "react-icons/go";
 
 const routes = {
@@ -20,17 +20,10 @@ const routes = {
 
 const TopNav = () => {
   const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const category = searchParams.get("category") || "none";
-  const page = searchParams.get("page") || "0";
-
   const isHome = pathname === routes.home;
   const isLessons = pathname.startsWith(routes.lessons);
   const isPools = pathname.startsWith(routes.pools);
-  const isCommunity =
-    pathname.startsWith(routes.community) &&
-    category === "none" &&
-    page === "0";
+  const isCommunity = pathname.startsWith(routes.community);
   const isMypage = pathname.startsWith(routes.mypage);
   const isLogin = pathname.startsWith(routes.login);
 

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -24,7 +24,7 @@ const LoginPage = ({ searchParams }: Props) => {
   };
   
   return (
-    <div className="flex-1 h-full flex flex-col bg-primary">
+    <div className="lg:w-full flex-1 h-full flex flex-col bg-primary">
       <div className="flex-1 flex items-center justify-center">
         <Image alt="로고" src="/image/logo_b.png" width={160} height={160} />
       </div>

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -22,56 +22,59 @@ const LoginPage = ({ searchParams }: Props) => {
     });
     window.location.href = `https://kauth.kakao.com/oauth/authorize?${params.toString()}`;
   };
-  
+
   return (
-    <div className="lg:w-full flex-1 h-full flex flex-col bg-primary">
-      <div className="flex-1 flex items-center justify-center">
-        <Image alt="로고" src="/image/logo_b.png" width={160} height={160} />
-      </div>
+    <div className="fixed inset-0 bg-primary -z-10">
+      <div className="min-h-screen flex flex-col xl:items-center xl:justify-center">
+        <div className="flex-1 flex items-center justify-center">
+          <Image alt="로고" src="/image/logo_b.png" width={160} height={160} />
+        </div>
 
-      <div className="flex flex-col gap-2 p-4">
-        <button
-          className="flex items-center justify-center gap-1 h-12 rounded-lg bg-[#FEE500]"
-          onClick={handleKakaoLogin}
-        >
-          <Image
-            alt="카카오톡 로그인"
-            src="/icon/kakao_2.png"
-            width={24}
-            height={24}
-          />
-          <span className="text-body_sm text-gray-900">카카오톡 로그인</span>
-        </button>
-        <Link
-          href="/"
-          className="flex items-center justify-center gap-1 h-12 rounded-lg bg-primary-sub text-primary-foreground"
-        >
-          <span className="text-body_sm">게스트로 시작하기</span>
-        </Link>
-      </div>
-
-      <div className="flex flex-col items-center gap-2 px-4 pt-4 pb-10">
-        <span className="text-body_sr text-gray-500">
-          로그인함으로서 다이브인의 정책 및 약관에 동의합니다.
-        </span>
-        <div className="flex gap-2 items-center">
-          <Link
-            href="https://pumped-nectarine-f16.notion.site/114b214c431780a99c94dfc758221271"
-            target="_blank"
-            className="text-body_sr text-gray-500"
+        <div className="flex flex-col gap-4 px-6 md:w-96 md:self-center">
+          <button
+            className="flex items-center justify-center gap-1 h-12 rounded-lg bg-[#FEE500]"
+            onClick={handleKakaoLogin}
           >
-            개인보호정책
-          </Link>
-          <span className="text-body_sr text-gray-500">|</span>
+            <Image
+              alt="카카오톡 로그인"
+              src="/icon/kakao_2.png"
+              width={24}
+              height={24}
+            />
+            <span className="text-body_sm text-gray-900">카카오톡 로그인</span>
+          </button>
           <Link
-            href="https://pumped-nectarine-f16.notion.site/114b214c431780ff833dc6c281646b9b"
-            target="_blank"
-            className="text-body_sr text-gray-500"
+            href="/"
+            className="flex items-center justify-center gap-1 h-12 rounded-lg bg-primary-sub text-primary-foreground"
           >
-            서비스 약관
+            <span className="text-body_sm">게스트로 시작하기</span>
           </Link>
         </div>
+
+        <div className="flex flex-col items-center gap-2 px-4 pt-4 pb-10">
+          <span className="text-body_sr text-gray-500">
+            로그인함으로서 다이브인의 정책 및 약관에 동의합니다.
+          </span>
+          <div className="flex gap-2 items-center">
+            <Link
+              href="https://pumped-nectarine-f16.notion.site/114b214c431780a99c94dfc758221271"
+              target="_blank"
+              className="text-body_sr text-gray-500"
+            >
+              개인보호정책
+            </Link>
+            <span className="text-body_sr text-gray-500">|</span>
+            <Link
+              href="https://pumped-nectarine-f16.notion.site/114b214c431780ff833dc6c281646b9b"
+              target="_blank"
+              className="text-body_sr text-gray-500"
+            >
+              서비스 약관
+            </Link>
+          </div>
+        </div>
       </div>
+
       {/* <div className="flex flex-col">
         <button
           className="h-14 flex items-center rounded-lg border pl-6 pr-4 bg-slate-50 hover:bg-slate-100"

--- a/src/app/clientPage.tsx
+++ b/src/app/clientPage.tsx
@@ -38,7 +38,7 @@ export default function HomeClient({ home }: { home: HomeProps }) {
               router.push("/search");
             }}
           >
-            <div className="relative w-full">
+            <div className="px-2 relative w-full">
               <input
                 type="text"
                 value={homeKeyword}

--- a/src/app/clientPage.tsx
+++ b/src/app/clientPage.tsx
@@ -68,7 +68,7 @@ export default function HomeClient({ home }: { home: HomeProps }) {
           </Link>
         </div>
         {/* 카드리스트 */}
-        <div className="grid grid-cols-2 gap-6 px-8 py-1">
+        <div className="xl:grid-cols-3 grid grid-cols-2 gap-6 px-8 py-1">
           {popularLessons.map((lesson) => (
             <LessonCard key={lesson.id} lesson={lesson} />
           ))}
@@ -83,7 +83,7 @@ export default function HomeClient({ home }: { home: HomeProps }) {
           </Link>
         </div>
         {/* 카드리스트 */}
-        <div className="grid grid-cols-2 gap-6 px-8 py-1">
+        <div className="xl:grid-cols-3 grid grid-cols-2 gap-6 px-8 py-1">
           {NewLessons.map((lesson) => (
             <LessonCard key={lesson.id} lesson={lesson} />
           ))}

--- a/src/app/community/_components/FloatingButton.tsx
+++ b/src/app/community/_components/FloatingButton.tsx
@@ -2,18 +2,14 @@ import Link from "next/link";
 
 export default function FloatingButton() {
   return (
-    <div className="fixed bottom-20 left-20 right-0 z-50 pointer-events-none">
-      <div className="max-w-3xl w-full mx-auto flex justify-end px-4">
         <Link
           href="/community/posts"
-          className="pointer-events-auto w-20 h-20 bg-blue-900 text-white rounded-full 
+          className="fixed bottom-20 right-6 z-50 lg:bottom-10 lg:right-10 w-20 h-20 bg-blue-900 text-white rounded-full 
         flex items-center justify-center shadow-lg hover:bg-blue-800"
         >
           <p className="text-4xl leading-none relative top-[-2px] hover:scale-110 transition-transform">
             +
           </p>
         </Link>
-      </div>
-    </div>
   );
 }

--- a/src/app/community/comments/Comment.tsx
+++ b/src/app/community/comments/Comment.tsx
@@ -117,7 +117,7 @@ export const Comment = ({
       )}
 
       <div
-        className={`fixed bottom-0 left-1/2 w-full transform -translate-x-1/2 bg-white p-4 pt-6 pb-6 border-t rounded-t-2xl transition-transform duration-300 ${
+        className={`fixed bottom-0 left-1/2 w-full transform -translate-x-1/2 bg-white py-4 px-6 border-t rounded-t-2xl transition-transform duration-300 ${
           isMenuOpen ? "translate-y-0" : "translate-y-full"
         }`}
         style={{ zIndex: 100, width: "100%", maxWidth: "48rem", boxShadow: "0 -1px 3px rgba(0, 0, 0, 0.05)" }}

--- a/src/app/community/posts/[id]/_components/PostMenuSlide.tsx
+++ b/src/app/community/posts/[id]/_components/PostMenuSlide.tsx
@@ -21,7 +21,7 @@ export default function PostMenuSlide({ isOpen, onClose, onShare, onEdit, onDele
       )}
 
       <div
-        className={`fixed bottom-0 left-1/2 w-full transform -translate-x-1/2 bg-white p-4 pt-6 pb-6 border-t rounded-t-2xl transition-transform duration-300 ${
+        className={`fixed bottom-0 left-1/2 w-full transform -translate-x-1/2 bg-white py-4 px-6 border-t rounded-t-2xl transition-transform duration-300 ${
           isOpen ? "translate-y-0" : "translate-y-full"
         }`}
         style={{

--- a/src/app/community/posts/[id]/clientPage.tsx
+++ b/src/app/community/posts/[id]/clientPage.tsx
@@ -163,7 +163,7 @@ export default function ClientCommunity({ postId, currentUserId }: { postId: num
   if (!community) return null;
 
   return (
-    <div className="flex flex-col pb-10 relative h-full">
+    <div className="flex flex-col xl:px-6 pb-10 relative h-full">
       {/* 상단Nav */}
       <div className="flex items-center justify-between py-1 px-1">
         <button type="button" aria-label="뒤로 가기" className="flex p-3" onClick={() => router.back()}>
@@ -207,7 +207,7 @@ export default function ClientCommunity({ postId, currentUserId }: { postId: num
         </div>
       </div>
 
-      <div className="px-4 py-6">
+      <div className="px-6 py-6">
         <h1 className="text-2xl font-bold">{community.title}</h1>
         <p className="text-gray-700 mt-4 whitespace-pre-line">
           {community.content}

--- a/src/app/community/posts/[id]/edit/page.tsx
+++ b/src/app/community/posts/[id]/edit/page.tsx
@@ -36,11 +36,17 @@ export default function EditPost({ params }: EditPostProps) {
   >([]);
   const [newImages, setNewImages] = useState<File[]>([]);
   const fileInputRef = useRef<HTMLInputElement | null>(null); //input참조
+  const [isLoading, setIsLoading] = useState(false);
   const postId = params.id;
 
   const [isLinkOpen, setIsLinkOpen] = useState(false);
   const [link, setLink] = useState("");
-  type OgPreview = { title: string; description: string; image: string | null; url: string };
+    type OgPreview = {
+    title: string;
+    description: string;
+    image: string | null;
+    url: string;
+  };
   const [preview, setPreview] = useState<OgPreview | null>(null); //OG데이터
   const containerRef = useRef<HTMLDivElement | null>(null);
   const router = useRouter();
@@ -140,7 +146,10 @@ useEffect(() => {
         newImages.map(async (file) => {
           const fd = new FormData();
           fd.append("file", file);
-          const res = await fetch("/api/community/upload", { method: "POST", body: fd });
+         const res = await fetch("/api/community/upload", {
+            method: "POST",
+            body: fd,
+          });
           const data = await res.json().catch(() => ({}));
           if (!res.ok) throw new Error(data.error || "이미지 업로드 실패");
           return data.imageUrls as string; //백엔드랑 변수명 같아야 함
@@ -254,21 +263,31 @@ useEffect(() => {
   };
 
   return (
-    <div className="flex flex-col h-screen pb-[4.5rem]">
-      <div className="flex items-center justify-between py-1 px-1">
-        <Link href={`/community/posts/${postId}`} className="flex p-3">
+    <div className="flex flex-col h-screen pb-[4.5rem] xl:pb-0 px-6">
+      <div className="flex items-center justify-between py-1 xl:justify-end">
+        <Link
+          href="/community/posts/list?category=none"
+          className="xl:hidden flex p-3"
+        >
           <ArrowLeftIcon className="w-6 h-6 text-gray-900" />
         </Link>
 
-        <h2 className="text-heading_3 font-bold text-center">글쓰기</h2>
+        <h2 className="xl:hidden text-body_bb font-bold text-center">글쓰기</h2>
 
-        <button type="submit" form="createPostForm" className="flex p-3">
-          <IoCheckmark className="w-6 h-6 text-gray-400 hover:text-blue-900" />
+    <button
+          type="submit"
+          form="createPostForm"
+          className="flex p-3 xl:pr-6"
+          disabled={isLoading}
+        >
+          <IoCheckmark
+            className={`w-6 h-6 ${isLoading ? "text-gray-200" : "text-gray-400 hover:text-blue-900"}`}
+          />
         </button>
       </div>
 
       {/* 카테고리 */}
-      <div className="relative px-4 py-4">
+       <div className="relative xl:px-4 py-4">
         <button
           className="flex items-center justify-between w-full px-4 py-3 text-left text-sm font-bold border bg-gray-100 border-gray-300 rounded-xl text-gray-700 focus:outline-none"
           onClick={() => setIsOpen((prev) => !prev)}
@@ -303,7 +322,7 @@ useEffect(() => {
           </div>
         )}
       </div>
-      <div className="flex-1 overflow-y-auto scrollbar-hide px-4">
+      <div className="flex-1 overflow-y-auto scrollbar-hide px-2">
         <form
           id="createPostForm"
           onSubmit={handleSubmit}
@@ -411,8 +430,9 @@ useEffect(() => {
           <button type="submit" className="hidden"></button>
 
           {/* 이미지 및 링크 삽입 버튼 */}
-          <div className="fixed w-full bottom-14 p-4 pt-4 max-w-[48rem] bg-white border-t border-gray-300">
-            <div className="flex justify-start items-center jusfity-center gap-8 px-3 text-gray-500">
+           <div className="fixed left-0 w-full bottom-14 xl:bottom-0 bg-white">
+            <div className="mx-8 border-t border-gray-300">
+              <div className="max-w-7xl mx-auto px-4 py-4 flex items-center gap-8 text-gray-500">
               <button type="button" onClick={handleImageButtonClick}>
                 <MdOutlineBrokenImage className="w-5 h-5 hover:text-blue-900" />
               </button>
@@ -420,6 +440,7 @@ useEffect(() => {
                 <AiOutlineLink className="w-5 h-5 hover:text-blue-900" />
               </button>
             </div>
+          </div>
           </div>
         </form>
       </div>

--- a/src/app/community/posts/list/clientPage.tsx
+++ b/src/app/community/posts/list/clientPage.tsx
@@ -65,7 +65,7 @@ export default function CommunitiesClient({
 
   return (
     <div>
-      <div className="mb-4 px-4 grid grid-cols-3 gap-2 md:flex md:flex-nowrap md:gap-2">
+      <div className="mb-4 px-6 grid grid-cols-3 gap-2 md:flex md:flex-nowrap md:gap-2">
         {CATEGORIES.map((c) => (
           <button
             key={c.key}
@@ -82,7 +82,7 @@ export default function CommunitiesClient({
         ))}
       </div>
 
-      <ul className="flex flex-col gap-1 px-4 pb-10">
+      <ul className="flex flex-col gap-1 px-8 pb-10">
         {items.length > 0 ? (
           items.map((community) => (
             <CategoryFilter

--- a/src/app/community/posts/list/page.tsx
+++ b/src/app/community/posts/list/page.tsx
@@ -13,7 +13,7 @@ export default async function CommunityPage({
 
   return (
     <div className="flex flex-col">
-      <header className="flex gap-2 pt-4 px-4">
+      <header className="flex gap-2 pt-4 px-4 xl:hidden">
         <div className="flex items-center gap-2">
           <Image
             alt="로고"

--- a/src/app/community/posts/list/page.tsx
+++ b/src/app/community/posts/list/page.tsx
@@ -12,7 +12,7 @@ export default async function CommunityPage({
     CATEGORIES.find((cate) => cate.key === category)?.name || "전체";
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col xl:px-6">
       <header className="flex gap-2 pt-4 px-4 xl:hidden">
         <div className="flex items-center gap-2">
           <Image

--- a/src/app/community/posts/page.tsx
+++ b/src/app/community/posts/page.tsx
@@ -33,7 +33,12 @@ export default function CreatePost() {
   const isSubmittingRef = useRef(false);
   const [isLinkOpen, setIsLinkOpen] = useState(false);
   const [link, setLink] = useState("");
-  type OgPreview = { title: string; description: string; image: string | null; url: string };
+  type OgPreview = {
+    title: string;
+    description: string;
+    image: string | null;
+    url: string;
+  };
   const [preview, setPreview] = useState<OgPreview | null>(null); //OG데이터
   const router = useRouter();
 
@@ -50,7 +55,7 @@ export default function CreatePost() {
 
     // validation 먼저 — 실패 시 isLoading 건드리지 않음
     const selectedCategoryKey = CATEGORIES.find(
-      (category) => category.name === selectedCategory
+      (category) => category.name === selectedCategory,
     )?.key;
     if (!selectedCategoryKey) {
       toast.error("카테고리를 선택해주세요!");
@@ -81,17 +86,22 @@ export default function CreatePost() {
         images.map(async (file) => {
           const fd = new FormData();
           fd.append("file", file);
-          const res = await fetch("/api/community/upload", { method: "POST", body: fd });
+          const res = await fetch("/api/community/upload", {
+            method: "POST",
+            body: fd,
+          });
           const data = await res.json().catch(() => ({}));
           if (!res.ok) throw new Error(data.error || "이미지 업로드 실패");
-          return data.imageUrls as string;  //백엔드랑 변수명 같아야 함
-        })
+          return data.imageUrls as string; //백엔드랑 변수명 같아야 함
+        }),
       );
       const postId = await createCommunity(formData, imageUrls);
       router.replace(`/community/posts/${postId}`);
     } catch (err) {
       console.error("글 작성 실패", err);
-      toast.error(err instanceof Error ? err.message : "글 작성에 실패했습니다.");
+      toast.error(
+        err instanceof Error ? err.message : "글 작성에 실패했습니다.",
+      );
     } finally {
       isSubmittingRef.current = false;
       setIsLoading(false);
@@ -166,21 +176,31 @@ export default function CreatePost() {
   };
 
   return (
-    <div className="flex flex-col h-screen pb-[4.5rem]">
-      <div className="flex items-center justify-between py-1 px-1">
-        <Link href="/community/posts/list?category=none" className="flex p-3">
+    <div className="flex flex-col h-screen pb-[4.5rem] xl:pb-0 px-6">
+      <div className="flex items-center justify-between py-1 xl:justify-end">
+        <Link
+          href="/community/posts/list?category=none"
+          className="xl:hidden flex p-3"
+        >
           <ArrowLeftIcon className="w-6 h-6 text-gray-900" />
         </Link>
 
-        <h2 className="text-heading_3 font-bold text-center">글쓰기</h2>
+        <h2 className="xl:hidden text-body_bb font-bold text-center">글쓰기</h2>
 
-        <button type="submit" form="createPostForm" className="flex p-3" disabled={isLoading}>
-          <IoCheckmark className={`w-6 h-6 ${isLoading ? "text-gray-200" : "text-gray-400 hover:text-blue-900"}`} />
+        <button
+          type="submit"
+          form="createPostForm"
+          className="flex p-3 xl:pr-6"
+          disabled={isLoading}
+        >
+          <IoCheckmark
+            className={`w-6 h-6 ${isLoading ? "text-gray-200" : "text-gray-400 hover:text-blue-900"}`}
+          />
         </button>
       </div>
 
       {/* 카테고리 */}
-      <div className="relative px-4 py-4">
+      <div className="relative xl:px-4 py-4">
         <button
           className="flex items-center justify-between w-full px-4 py-3 text-left text-sm font-bold border bg-gray-100 border-gray-300 rounded-xl text-gray-700 focus:outline-none"
           onClick={() => setIsOpen((prev) => !prev)}
@@ -211,13 +231,12 @@ export default function CreatePost() {
                   </li>
                 ))}
               </ul>
-
             </div>
           </div>
         )}
       </div>
 
-      <div className="flex-1 overflow-y-auto scrollbar-hide px-4">
+      <div className="flex-1 overflow-y-auto scrollbar-hide px-2">
         <form
           id="createPostForm"
           onSubmit={handleSubmit}
@@ -304,30 +323,30 @@ export default function CreatePost() {
           <button type="submit" className="hidden"></button>
 
           {/* 이미지 및 링크 삽입 버튼 */}
-          <div className="fixed w-full bottom-14 p-4 pt-4 max-w-[48rem] bg-white border-t border-gray-300">
-            <div className="flex justify-start items-center jusfity-center gap-8 px-3 text-gray-500">
-              <button type="button" onClick={handleImageButtonClick}>
-                <MdOutlineBrokenImage className="w-5 h-5 hover:text-blue-900" />
-              </button>
-              <button type="button" onClick={toggleSlide}>
-                <AiOutlineLink className="w-5 h-5 hover:text-blue-900" />
-              </button>
+          <div className="fixed left-0 w-full bottom-14 xl:bottom-0 bg-white">
+            <div className="mx-8 border-t border-gray-300">
+              <div className="max-w-7xl mx-auto px-4 py-4 flex items-center gap-8 text-gray-500">
+                <button type="button" onClick={handleImageButtonClick}>
+                  <MdOutlineBrokenImage className="w-5 h-5 hover:text-blue-900" />
+                </button>
+                <button type="button" onClick={toggleSlide}>
+                  <AiOutlineLink className="w-5 h-5 hover:text-blue-900" />
+                </button>
+              </div>
             </div>
           </div>
-
         </form>
       </div>
 
       {/* 링크 슬라이드 */}
-      
-        <OpenGraphPreview
-          url={link}
-          setUrl={setLink}
-          onConfirm={handleSubmitLink}
-          onClose={() => setIsLinkOpen(false)}
-          isOpen={isLinkOpen}
-        />
-     
+
+      <OpenGraphPreview
+        url={link}
+        setUrl={setLink}
+        onConfirm={handleSubmitLink}
+        onClose={() => setIsLinkOpen(false)}
+        isOpen={isLinkOpen}
+      />
     </div>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,8 +5,9 @@ import Script from "next/script";
 import KakaoSdkScript from "./_scripts/KakaoSdkScript";
 import { GoogleTagManager } from "@next/third-parties/google";
 import "./globals.css";
-import BottomNavWrapper from "./BottomNavWrapper";
+import BottomNavWrapper from "./_components/BottomNavWrapper";
 import TopNav from "./_components/TopNav";
+import ContentWrapper from "./_components/ContentWrapper";
 
 const KAKAO_APP_KEY = process.env.NEXT_PUBLIC_KAKAO_APP_KEY!;
 
@@ -35,15 +36,13 @@ export default async function RootLayout({
       <body
         className={`${pretendard.variable} antialiased flex flex-col items-center h-dvh`}
       >
-          <div className="xl:pt-20 w-full flex-1 flex flex-col overflow-hidden">
-            <main className="flex-1 overflow-y-auto no-scrollbar">
-              <div className="lg:max-w-6xl xl:max-w-7xl mx-auto">
-                {children}
-              </div>
-            </main>
-            <BottomNavWrapper />
-          </div>
-          <TopNav />
+        <ContentWrapper>
+          <main className="flex-1 overflow-y-auto no-scrollbar">
+            <div className="lg:max-w-6xl xl:max-w-7xl mx-auto">{children}</div>
+          </main>
+          <BottomNavWrapper />
+        </ContentWrapper>
+        <TopNav />
 
         <Script
           id="kakao-map-sdk"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import KakaoSdkScript from "./_scripts/KakaoSdkScript";
 import { GoogleTagManager } from "@next/third-parties/google";
 import "./globals.css";
 import BottomNavWrapper from "./BottomNavWrapper";
+import TopNav from "./_components/TopNav";
 
 const KAKAO_APP_KEY = process.env.NEXT_PUBLIC_KAKAO_APP_KEY!;
 
@@ -34,12 +35,15 @@ export default async function RootLayout({
       <body
         className={`${pretendard.variable} antialiased flex flex-col items-center h-dvh`}
       >
-          <div className="max-w-3xl w-full flex-1 flex flex-col overflow-hidden">
+          <div className="xl:pt-20 w-full flex-1 flex flex-col overflow-hidden">
             <main className="flex-1 overflow-y-auto no-scrollbar">
-              {children}
+              <div className="lg:max-w-6xl xl:max-w-7xl mx-auto">
+                {children}
+              </div>
             </main>
             <BottomNavWrapper />
           </div>
+          <TopNav />
 
         <Script
           id="kakao-map-sdk"

--- a/src/app/lessons/page.tsx
+++ b/src/app/lessons/page.tsx
@@ -1,4 +1,6 @@
 import { getLessons } from "@/api/server/lessons";
+
+export const dynamic = 'force-dynamic';
 import LessonChip from "@/components/ui/Chip";
 import Link from "next/link";
 import InstructorProfile from "../_components/InstructorProfile";

--- a/src/app/lessons/page.tsx
+++ b/src/app/lessons/page.tsx
@@ -23,7 +23,7 @@ export default async function LessonsPage() {
 
   return (
     <div className="flex flex-col">
-      <header className="flex gap-2 pt-4 px-4">
+      <header className="flex gap-2 pt-4 px-4 xl:hidden">
         <div className="flex items-center gap-2">
           <Image
             alt="로고"
@@ -39,7 +39,7 @@ export default async function LessonsPage() {
           <h2 className="text-heading_2">수영 클래스</h2>
         </div>
 
-        <ul className="flex flex-col gap-6 px-4 pb-10">
+        <ul className="xl:grid xl:grid-cols-2 flex flex-col gap-6 px-6 pb-10">
           {lessons.map((lesson) => (
             <li key={lesson.id}>
               <Link

--- a/src/app/lessons/page.tsx
+++ b/src/app/lessons/page.tsx
@@ -22,7 +22,7 @@ export default async function LessonsPage() {
   const lessons = await getLessons();
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col xl:px-6">
       <header className="flex gap-2 pt-4 px-4 xl:hidden">
         <div className="flex items-center gap-2">
           <Image

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -13,7 +13,7 @@ const MyPage = async () => {
   const isLogin = !!user;
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col xl:px-6">
       <div className="flex pt-10 px-4 pb-5">
         <h1 className="text-heading_2">마이 페이지</h1>
       </div>

--- a/src/app/notice/page.tsx
+++ b/src/app/notice/page.tsx
@@ -9,7 +9,7 @@ const Page = async () => {
         width={120}
         height={120}
         priority
-        className="w-[120px] h-[120px]"
+        className="xl:hidden w-[120px] h-[120px]"
       />
       <span className="text-body_bm text-gray-600">
         이 페이지는 준비중입니다.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ export default async function Home() {
 
   return (
     <div className="flex flex-col">
-         <header className="flex gap-2 pt-4 px-4">
+         <header className="flex gap-2 pt-4 px-4 xl:hidden">
            <div className="flex items-center gap-2">
              <Image
                alt="로고"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,6 @@
 import { getHome } from "@/api/server/home";
+
+export const dynamic = 'force-dynamic';
 import Image from "next/image";
 import HomeClient from "./clientPage";
 

--- a/src/app/pools/page.tsx
+++ b/src/app/pools/page.tsx
@@ -8,7 +8,7 @@ const PoolsPage = async () => {
 
   return (
     <div className="flex flex-col">
-      <header className="flex gap-2 pt-4 px-4">
+      <header className="flex gap-2 pt-4 px-4 xl:hidden">
         <div className="flex items-center gap-2">
           <Image
             alt="로고"
@@ -25,7 +25,7 @@ const PoolsPage = async () => {
           <h2 className="text-heading_2 text-gray-900">수영장</h2>
         </div>
 
-        <ul className="grid grid-cols-2 gap-4 px-4 pb-10">
+        <ul className="xl:grid-cols-3 grid grid-cols-2 gap-6 px-6 pb-10">
           {pools.map((pool, index) => (
             <li key={pool.id}>
               <Link

--- a/src/app/pools/page.tsx
+++ b/src/app/pools/page.tsx
@@ -1,4 +1,6 @@
 import { getPools } from "@/api/server/pools";
+
+export const dynamic = 'force-dynamic';
 import LessonChip from "@/components/ui/Chip";
 import Image from "next/image";
 import Link from "next/link";

--- a/src/app/pools/page.tsx
+++ b/src/app/pools/page.tsx
@@ -7,7 +7,7 @@ const PoolsPage = async () => {
   const pools = await getPools();
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col xl:px-6">
       <header className="flex gap-2 pt-4 px-4 xl:hidden">
         <div className="flex items-center gap-2">
           <Image

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -6,7 +6,7 @@ import PoolIcon from "@/components/icons/PoolIcon";
 import SwimHatIcon from "@/components/icons/SwimHatIcon";
 import { useEffect } from "react";
 import { getSearch } from "@/api/server/search";
-import BackButton from "../_components/BackButton";
+import BackButton from "@/app/_components/BackButton";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useSearchStore } from "@/store/searchStore";
 import { IoCloseOutline } from "react-icons/io5";

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -6,7 +6,7 @@ import PoolIcon from "@/components/icons/PoolIcon";
 import SwimHatIcon from "@/components/icons/SwimHatIcon";
 import { useEffect } from "react";
 import { getSearch } from "@/api/server/search";
-import BackButton from "../_components/backButton";
+import BackButton from "../_components/BackButton";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useSearchStore } from "@/store/searchStore";
 import { IoCloseOutline } from "react-icons/io5";


### PR DESCRIPTION
**[P15] 반응형 웹 - TopNav, Grid, Login PC 레이아웃**
-

<h3>[배경]</h3>

- 모바일 단일 컬럼 구조에서 PC 레이아웃 대응이 없다는 외부 피드백을 반영해 반응형 웹 구현

<h3>[문제]</h3>

1. 모바일 전용 BottomNav만 있고 PC 네비게이션 없음
2. 전체 레이아웃 max-w-3xl(768px) 고정으로 PC에서 빈 공간 과다
3. 로그인 페이지가 PC에서 배경이 화면을 못 채우고 요소 배치 틀어짐

<h3>[작업 내용]</h3>

**1. TopNav.tsx 신규 생성**: xl(1280px) 이상 상단 고정 네비게이션, 로고 좌측 + 메뉴 중앙 정렬 + overflow-hidden 적용
- 처음에는 SideNav였으나 생각보다 맘에 들지 않아 새로 작업시작
<img width="884" height="590" alt="image" src="https://github.com/user-attachments/assets/0edcb0b4-7f24-45f1-9c12-0de992edf381" />
<br/>
- 모바일은 그대로 BottomNav유지, PC일 때 TopNav로 변경
<img width="1818" height="306" alt="image" src="https://github.com/user-attachments/assets/8a5f0a47-5327-4461-8aab-e61d1094b951" />
<br/>

**2. layout.tsx:** max-w-3xl 제거, xl:pt-16, 콘텐츠 캡 lg:max-w-6xl xl:max-w-7xl mx-auto
**3. BottomNav.tsx:** xl:hidden 추가
**4. ContentWrapper.tsx 신규:** 로그인 페이지에서 xl:pt-16 미적용 처리
**5. 각 페이지 헤더 로고:** xl:hidden (홈/수업/수영장/커뮤니티/notice)
**6. 수업/수영장/홈 카드 그리드 적용** (xl:grid-cols-2, xl:grid-cols-3)

<br/>

**[수업]**
<img width="1880" height="766" alt="image" src="https://github.com/user-attachments/assets/e0c323df-a6af-4d06-af49-ac86d113c88e" />
<br/>
**[수영장]**
<img width="1846" height="788" alt="image" src="https://github.com/user-attachments/assets/7a8dddc4-b503-4583-a08b-22f37ed42dcd" />
<br/>
**[홈]**
<img width="1880" height="734" alt="image" src="https://github.com/user-attachments/assets/0203850c-2be2-4a01-b3ce-1a845df2d045" />
<br/>
**7.글 작성/수정 툴바 PC 대응** (xl:bottom-0, 3단 wrapper 구조로 border 정렬)
**8. 로그인 페이지:** fixed inset-0 bg-primary 배경 분리, PC 중앙 정렬 및 버튼 lg:w-96 적용

<h3>[결과 및 개선]</h3>

- 1280px 이상에서 TopNav 표시, BottomNav 숨김
- 카드 목록 2~3열 그리드 전환
- 브레이크포인트 lg→xl 조정으로 1024~1279px 구간 레이아웃 깨짐 해결

**[수정 전]**
<img width="1612" height="334" alt="image" src="https://github.com/user-attachments/assets/608ebdd5-802c-455a-bf8c-3f005d592ec7" />
<br/>

**[수정 후 - xl크기(Tailwind: 1280px)부터 TopNav적용]**
<img width="1594" height="246" alt="image" src="https://github.com/user-attachments/assets/083b89d0-c4fa-419b-b50c-12f3e52fda0b" />
**[수정 후 - xl크기(Tailwind: 1280px) 전까지는 BottomNav적용]**
<img width="1514" height="210" alt="image" src="https://github.com/user-attachments/assets/6ee4c9d3-1cde-41e4-b4a8-de8a5396e339" />

- 로그인 페이지 모든 크기에서 배경 full 적용, PC에서 버튼 중앙 정렬

<h3>[검증]</h3>

- 375px / 768px / 1280px / 1440px 브라우저 확인

<h3>[할 일]</h3>

- [ ] 데모 GIF 재촬영 후 README에 추가
- [ ] 프로덕션 E2E 테스트 (Vercel + Railway 배포 후)
- [x] P14: 이미지 업로드 (Supabase Storage)
- [x] P15: 반응형 웹
- [ ]  P16 - lessons/pools DB 연동 및 real API 전환