### PR TITLE
Feat: 커뮤니티 조회수 연동 및 수정 조회 분리

### DIFF
--- a/src/app/community/posts/[id]/clientPage.tsx
+++ b/src/app/community/posts/[id]/clientPage.tsx
@@ -28,8 +28,12 @@ export default function ClientCommunity({ postId, currentUserId }: { postId: num
   const [changeLiked, setChangeLiked] = useState(false);
   const [changeLikesCnt, setChangeLikesCnt] = useState(0);
   const router = useRouter();
+  const fetchedPostIdRef = useRef<number | null>(null);
 
   useEffect(() => {
+    if (fetchedPostIdRef.current === postId) return;
+    fetchedPostIdRef.current = postId;
+
     getCommunity(String(postId)).then((post) => {
       if (!post) {
         router.back();

--- a/src/app/community/posts/[id]/edit/page.tsx
+++ b/src/app/community/posts/[id]/edit/page.tsx
@@ -11,7 +11,7 @@ import { CATEGORYNAME_TO_LABEL } from "@/constants/categories";
 import { useRouter } from "next/navigation";
 import toast from "react-hot-toast";
 import OpenGraphPreview from "@/app/_components/OpenGraphLinkReview";
-import { getCommunity, updateCommunity } from "@/services/community";
+import { getCommunityForEdit, updateCommunity } from "@/services/community";
 
 const CATEGORIES = [
   { name: "소통해요", key: "COMMUNICATION" },
@@ -117,7 +117,7 @@ useEffect(() => {
   useEffect(() => {
     const fetchPost = async () => {
       try {
-        const post = await getCommunity(postId);
+        const post = await getCommunityForEdit(postId);
         if (!post) {
           throw new Error("게시글을 불러올 수 없습니다.");
         }

--- a/src/services/community/index.ts
+++ b/src/services/community/index.ts
@@ -9,7 +9,7 @@ export const getCommunity = useMock? mockServer.getCommunity : real.getCommunity
 export const getComments = useMock? mockServer.getComments : real.getComments;
 export const createCommunity = useMock ? mockClient.createCommunity : real.createCommunity;
 
-// 인증 필요 뮤테이션 — mock 없음, real만 사용
+// 인증 필요 작업 — mock 없음, real만 사용
 export {
   createComment,
   updateCommunity,
@@ -18,4 +18,5 @@ export {
   deleteLikePost,
   updateComment,
   deleteComment,
+  getCommunityForEdit,
 } from "./real";

--- a/src/services/community/real.ts
+++ b/src/services/community/real.ts
@@ -35,8 +35,8 @@ export const getCommunity = async (postId: string): Promise<CommunityProps|null>
       `${process.env.NEXT_PUBLIC_API_BASE_URL}/community/posts/${postId}`,
       {
         method: "GET",
+        cache: "no-store", //캐싱 방지
         headers: {
-          "Cache-Control": "no-cache", //캐싱 방지
           "Content-Type": "application/json",
         },
       }
@@ -62,6 +62,33 @@ export const getCommunity = async (postId: string): Promise<CommunityProps|null>
     return transformedData;
   } catch (error) {
     console.error("[getCommunity] error::", error);
+    return null;
+  }
+};
+
+export const getCommunityForEdit = async (postId: string): Promise<CommunityProps|null> => {
+  try {
+    const accessToken = cookies().get("accessToken")?.value;
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_BASE_URL}/community/posts/${postId}/edit`,
+      {
+        method: "GET",
+        cache: "no-store",
+        headers: {
+          "Content-Type": "application/json",
+          ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`HTTP에러 상태 코드: ${response.status}`);
+    }
+
+    const body = await response.json();
+    return communityDetailSchema.parse(body.data);
+  } catch (error) {
+    console.error("[getCommunityForEdit] error::", error);
     return null;
   }
 };


### PR DESCRIPTION
**커뮤니티 조회수 연동 및 수정 조회 분리**
-

<h3>[배경]</h3>

- 일반 상세 조회와 게시글 수정 데이터 조회가 같은 함수를 사용해 수정 화면도 조회수에 포함될 가능성 존재

<h3>[작업 내용]</h3>

1. 일반 상세 요청에 cache: "no-store"를 적용
2. 개발 모드의 중복 상세 요청을 방지
3. 작성자 전용 getCommunityForEdit()를 추가
4. 수정 페이지가 비집계 수정 조회 API를 사용하도록 변경

<h3>[검증]</h3>

- Vitest 7개 통과
- TypeScript noEmit 검사 통과
- ESLint는 초기 설정 질문이 표시되어 자동 검증하지 못함
- production build는 실행 제한 시간 초과로 완료 여부 미확인

<h3>[할 일]</h3>

- [ ] 데모 GIF 재촬영 후 README에 추가
- [ ] Vercel production 확인